### PR TITLE
[#176924316] Add Start EYCA activation api

### DIFF
--- a/ContinueEycaActivation/index.ts
+++ b/ContinueEycaActivation/index.ts
@@ -5,10 +5,11 @@ import { fromEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { StatusEnum } from "../generated/definitions/CardPendingStatus";
 import { OrchestratorInput } from "../StartEycaActivationOrchestrator/index";
 import { trackException } from "../utils/appinsights";
 import { Failure, PermanentFailure, TransientFailure } from "../utils/errors";
-import { makeEycaActivationOrchestratorId } from "../utils/orchestrators";
+import { makeEycaOrchestratorId } from "../utils/orchestrators";
 
 export const ContinueEycaActivationInput = t.type({
   fiscalCode: FiscalCode
@@ -44,7 +45,7 @@ export const index: AzureFunction = (
         () =>
           df.getClient(context).startNew(
             "StartEycaActivationOrchestrator",
-            makeEycaActivationOrchestratorId(fiscalCode),
+            makeEycaOrchestratorId(fiscalCode, StatusEnum.PENDING),
             OrchestratorInput.encode({
               fiscalCode
             })

--- a/ContinueEycaActivation/index.ts
+++ b/ContinueEycaActivation/index.ts
@@ -5,7 +5,7 @@ import { fromEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
-import { StatusEnum } from "../generated/definitions/CardPendingStatus";
+import { StatusEnum } from "../generated/definitions/CardPending";
 import { OrchestratorInput } from "../StartEycaActivationOrchestrator/index";
 import { trackException } from "../utils/appinsights";
 import { Failure, PermanentFailure, TransientFailure } from "../utils/errors";

--- a/GetEycaActivation/__tests__/handler.test.ts
+++ b/GetEycaActivation/__tests__/handler.test.ts
@@ -1,0 +1,253 @@
+/* tslint:disable: no-any */
+import * as date_fns from "date-fns";
+import { OrchestrationRuntimeStatus } from "durable-functions/lib/src/classes";
+import { some } from "fp-ts/lib/Option";
+import { none } from "fp-ts/lib/Option";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { now } from "../../__mocks__/mock";
+import { StatusEnum as ActivatedStatusEnum } from "../../generated/definitions/CardActivated";
+import {
+  CardPending,
+  StatusEnum as PendingStatusEnum
+} from "../../generated/definitions/CardPending";
+import { StatusEnum } from "../../generated/definitions/CgnActivationDetail";
+import { EycaActivationDetail } from "../../generated/definitions/EycaActivationDetail";
+import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated";
+import { UserEycaCard } from "../../models/user_eyca_card";
+import * as orchUtils from "../../utils/orchestrators";
+import { GetEycaActivationHandler } from "../handler";
+
+const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
+const aCardNumber = "AAAAA" as NonEmptyString;
+
+const anInstanceId = {
+  id: orchUtils.makeUpdateCgnOrchestratorId(
+    aFiscalCode,
+    "ACTIVATED"
+  ) as NonEmptyString
+};
+const aCompletedResponse: EycaActivationDetail = {
+  status: StatusEnum.COMPLETED
+};
+const aPendingEycaCard: CardPending = {
+  status: PendingStatusEnum.PENDING
+};
+
+const anActivatedEyca: EycaCardActivated = {
+  activation_date: now,
+  card_number: aCardNumber,
+  expiration_date: date_fns.addDays(now, 10),
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const aUserEycaCard: UserEycaCard = {
+  card: aPendingEycaCard,
+  fiscalCode: aFiscalCode
+};
+
+const findLastVersionByModelIdMock = jest
+  .fn()
+  .mockImplementation(() =>
+    taskEither.of(some({ ...aUserEycaCard, card: anActivatedEyca }))
+  );
+const userEycaCardModelMock = {
+  findLastVersionByModelId: findLastVersionByModelIdMock
+};
+
+const getOrchestratorStatusMock = jest
+  .fn()
+  .mockImplementation((_, __) =>
+    taskEither.of({ instanceId: anInstanceId, customStatus: "COMPLETED" })
+  );
+jest
+  .spyOn(orchUtils, "getOrchestratorStatus")
+  .mockImplementation(getOrchestratorStatusMock);
+
+describe("GetEycaActivationHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should return success with ERROR status if orchestrator status is Failed", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Failed
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.ERROR
+      });
+    }
+  });
+
+  it("should return success with RUNNING status if orchestrator status is Running", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Running
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.RUNNING
+      });
+    }
+  });
+  it("should return success if an orchestrator's custom status is UPDATED", async () => {
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success if an orchestrator's custom status is COMPLETED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({ instanceId: anInstanceId, customStatus: "COMPLETED" })
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return an internal error if there are errors to retrieve a UserCgn", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Query Error"))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return Not found if infos about orchestrator status and UserCgn are missing", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorNotFound");
+  });
+
+  it("should return Not found if infos about orchestrator status are not recognized and UserCgn are missing", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Canceled
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorNotFound");
+  });
+
+  it("should return success with COMPLETED status if orchestrator infos are missing and userCgn is already activated", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success with COMPLETED status if orchestrator check status raise an error but userCgn is already activated", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot recognize orchestrator status"))
+    );
+
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success with PENDING status if orchestrator infos are missing and userCgn is PENDING", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.PENDING
+      });
+    }
+  });
+
+  it("should return success with COMPLETED status if the orchestrator is terminated and userCgn is ACTIVATED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Terminated
+      })
+    );
+
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.COMPLETED
+      });
+    }
+  });
+
+  it("should return success with COMPLETED status if custom status is UPDATED and userCgn is ACTIVATED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        customStatus: "UPDATED",
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Running
+      })
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.COMPLETED
+      });
+    }
+  });
+});

--- a/GetEycaActivation/function.json
+++ b/GetEycaActivation/function.json
@@ -1,0 +1,25 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/cgn/{fiscalcode}/eyca/activation",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/GetEycaActivation/index.js"
+}

--- a/GetEycaActivation/handler.ts
+++ b/GetEycaActivation/handler.ts
@@ -1,0 +1,132 @@
+import * as express from "express";
+
+import { Context } from "@azure/functions";
+import * as df from "durable-functions";
+import { DurableOrchestrationStatus } from "durable-functions/lib/src/classes";
+import { Either, left, right } from "fp-ts/lib/Either";
+import { identity } from "fp-ts/lib/function";
+import { fromNullable } from "fp-ts/lib/Option";
+import { fromEither, taskEither } from "fp-ts/lib/TaskEither";
+import { fromLeft } from "fp-ts/lib/TaskEither";
+import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import {
+  withRequestMiddlewares,
+  wrapRequestHandler
+} from "io-functions-commons/dist/src/utils/request_middleware";
+import {
+  IResponseErrorInternal,
+  IResponseErrorNotFound,
+  IResponseSuccessJson,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { CardActivated } from "../generated/definitions/CardActivated";
+import { StatusEnum } from "../generated/definitions/CgnActivationDetail";
+import { EycaActivationDetail } from "../generated/definitions/EycaActivationDetail";
+import { UserEycaCardModel } from "../models/user_eyca_card";
+import { retrieveUserEycaCard } from "../utils/models";
+import {
+  getOrchestratorStatus,
+  makeEycaOrchestratorId
+} from "../utils/orchestrators";
+
+type ResponseTypes =
+  | IResponseSuccessJson<EycaActivationDetail>
+  | IResponseErrorNotFound
+  | IResponseErrorInternal;
+
+type IGetEycaActivationHandler = (
+  context: Context,
+  fiscalCode: FiscalCode
+) => Promise<ResponseTypes>;
+
+const mapOrchestratorStatus = (
+  orchestratorStatus: DurableOrchestrationStatus
+): Either<Error, StatusEnum> => {
+  if (
+    orchestratorStatus.customStatus === "UPDATED" ||
+    orchestratorStatus.customStatus === "COMPLETED"
+  ) {
+    return right(StatusEnum.COMPLETED);
+  }
+  switch (orchestratorStatus.runtimeStatus) {
+    case df.OrchestrationRuntimeStatus.Pending:
+      return right(StatusEnum.PENDING);
+    case df.OrchestrationRuntimeStatus.Running:
+    case df.OrchestrationRuntimeStatus.ContinuedAsNew:
+      return right(StatusEnum.RUNNING);
+    case df.OrchestrationRuntimeStatus.Failed:
+      return right(StatusEnum.ERROR);
+    case df.OrchestrationRuntimeStatus.Completed:
+      return right(StatusEnum.COMPLETED);
+    default:
+      return left(new Error("Cannot recognize status"));
+  }
+};
+
+export function GetEycaActivationHandler(
+  userEycaCardModel: UserEycaCardModel
+): IGetEycaActivationHandler {
+  return async (context, fiscalCode) => {
+    const client = df.getClient(context);
+    const orchestratorId = makeEycaOrchestratorId(
+      fiscalCode,
+      StatusEnum.PENDING
+    );
+    // first check if an activation process is running
+    return retrieveUserEycaCard(userEycaCardModel, fiscalCode)
+      .map(_ => _.card)
+      .chain(eycaCard =>
+        getOrchestratorStatus(client, orchestratorId)
+          .chain<EycaActivationDetail>(maybeOrchestrationStatus =>
+            fromNullable(maybeOrchestrationStatus).foldL(
+              () => fromLeft(new Error("Orchestrator instance not found")),
+              orchestrationStatus =>
+                // now try to map orchestrator status
+                fromEither(mapOrchestratorStatus(orchestrationStatus)).map(
+                  _ => ({
+                    created_at: orchestrationStatus.createdTime,
+                    last_updated_at: orchestrationStatus.lastUpdatedTime,
+                    status: _
+                  })
+                )
+            )
+          )
+          .foldTaskEither<
+            IResponseErrorInternal | IResponseErrorNotFound,
+            EycaActivationDetail
+          >(
+            () =>
+              // It's not possible to map any activation status
+              // check for EYCA Card status on cosmos
+              taskEither
+                .of<
+                  IResponseErrorInternal | IResponseErrorNotFound,
+                  StatusEnum
+                >(
+                  CardActivated.is(eycaCard)
+                    ? StatusEnum.COMPLETED
+                    : StatusEnum.PENDING
+                )
+                .map(_ => ({ status: _ })),
+            activationDetail => taskEither.of(activationDetail)
+          )
+      )
+      .fold<ResponseTypes>(identity, _ => ResponseSuccessJson(_))
+      .run();
+  };
+}
+
+export function GetEycaActivation(
+  userEycaCardModel: UserEycaCardModel
+): express.RequestHandler {
+  const handler = GetEycaActivationHandler(userEycaCardModel);
+
+  const middlewaresWrap = withRequestMiddlewares(
+    ContextMiddleware(),
+    RequiredParamMiddleware("fiscalcode", FiscalCode)
+  );
+
+  return wrapRequestHandler(middlewaresWrap(handler));
+}

--- a/GetEycaActivation/index.ts
+++ b/GetEycaActivation/index.ts
@@ -1,0 +1,56 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+
+import {
+  USER_EYCA_CARD_COLLECTION_NAME,
+  UserEycaCardModel
+} from "../models/user_eyca_card";
+import { getConfigOrThrow } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+import { GetEycaActivation } from "./handler";
+
+//
+//  CosmosDB initialization
+//
+
+const config = getConfigOrThrow();
+
+const userEycaCardsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_EYCA_CARD_COLLECTION_NAME);
+
+const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+secureExpressApp(app);
+
+// Add express route
+app.get(
+  "/api/v1/cgn/:fiscalcode/eyca/activation",
+  GetEycaActivation(userEycaCardModel)
+);
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/StartCgnActivation/__tests__/handler.test.ts
+++ b/StartCgnActivation/__tests__/handler.test.ts
@@ -70,10 +70,10 @@ const userCgnModelMock = {
   upsert: upsertModelMock
 };
 
-const checkUpdateCgnIsRunningMock = jest.fn();
+const checkUpdateCardIsRunningMock = jest.fn();
 jest
-  .spyOn(orchUtils, "checkUpdateCgnIsRunning")
-  .mockImplementation(checkUpdateCgnIsRunningMock);
+  .spyOn(orchUtils, "checkUpdateCardIsRunning")
+  .mockImplementation(checkUpdateCardIsRunningMock);
 describe("StartCgnActivation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -92,9 +92,11 @@ describe("StartCgnActivation", () => {
 
   it("should return an Internal Error if it is not possible to check status of an other orchestrator with the same id", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
-      taskEither.of(some({ ...aRevokedUserCgn, status: aUserCardPendingStatus }))
+      taskEither.of(
+        some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
+      )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       fromLeft(ResponseErrorInternal("Error"))
     );
     const startCgnActivationHandler = StartCgnActivationHandler(
@@ -106,9 +108,11 @@ describe("StartCgnActivation", () => {
 
   it("should return an Accepted response if there is another orchestrator running with the same id", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
-      taskEither.of(some({ ...aRevokedUserCgn, status: aUserCardPendingStatus }))
+      taskEither.of(
+        some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
+      )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       fromLeft(ResponseSuccessAccepted())
     );
     const startCgnActivationHandler = StartCgnActivationHandler(
@@ -120,9 +124,11 @@ describe("StartCgnActivation", () => {
 
   it("should start a new orchestrator if there aren' t conflict on the same id", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
-      taskEither.of(some({ ...aRevokedUserCgn, status: aUserCardPendingStatus }))
+      taskEither.of(
+        some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
+      )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       taskEither.of(false)
     );
     upsertModelMock.mockImplementationOnce(() => taskEither.of({}));
@@ -146,9 +152,11 @@ describe("StartCgnActivation", () => {
 
   it("should start an Internal Error if there are errors while inserting a new Cgn in pending status", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
-      taskEither.of(some({ ...aRevokedUserCgn, status: aUserCardPendingStatus }))
+      taskEither.of(
+        some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
+      )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       taskEither.of(false)
     );
     upsertModelMock.mockImplementationOnce(() =>

--- a/StartEycaActivation/__tests__/handler.test.ts
+++ b/StartEycaActivation/__tests__/handler.test.ts
@@ -1,0 +1,255 @@
+/* tslint:disable: no-any */
+import { addYears } from "date-fns";
+import { left, right } from "fp-ts/lib/Either";
+import { none, some } from "fp-ts/lib/Option";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+import { mockGetStatus, mockStartNew } from "../../__mocks__/durable-functions";
+import {
+  CardActivatedStatus,
+  StatusEnum as ActivatedStatusEnum
+} from "../../generated/definitions/CardActivatedStatus";
+import { StatusEnum as PendingStatusEnum } from "../../generated/definitions/CardPendingStatus";
+import { EycaCardActivatedStatus } from "../../generated/definitions/EycaCardActivatedStatus";
+import { UserCgn } from "../../models/user_cgn";
+import { UserEycaCard } from "../../models/user_eyca_card";
+import * as checks from "../../utils/cgn_checks";
+import * as orchUtils from "../../utils/orchestrators";
+
+import { ResponseSuccessAccepted } from "italia-ts-commons/lib/responses";
+import { StartEycaActivationHandler } from "../handler";
+
+const aFiscalCode = "RODFDS89S10H501T" as FiscalCode;
+const anEycaCardNumber = "AAAAA" as NonEmptyString;
+
+const aUserCardActivatedStatus: CardActivatedStatus = {
+  activation_date: new Date(),
+  expiration_date: addYears(new Date(), 2),
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const aUserEycaCardActivatedStatus: EycaCardActivatedStatus = {
+  activation_date: new Date(),
+  card_number: anEycaCardNumber,
+  expiration_date: addYears(new Date(), 2),
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const anActivatedUserCgn: UserCgn = {
+  fiscalCode: aFiscalCode,
+  id: "A_USER_CGN_ID" as NonEmptyString,
+  status: aUserCardActivatedStatus
+};
+
+const aUserEycaCard: UserEycaCard = {
+  cardStatus: aUserEycaCardActivatedStatus,
+  fiscalCode: aFiscalCode
+};
+
+const findLastVersionByModelIdMock = jest
+  .fn()
+  .mockImplementation(() => taskEither.of(some(anActivatedUserCgn)));
+const userCgnModelMock = {
+  findLastVersionByModelId: findLastVersionByModelIdMock
+};
+
+const findLastVersionEycaByModelIdMock = jest
+  .fn()
+  .mockImplementation(() => taskEither.of(none));
+const upsertMock = jest.fn().mockImplementation(() => taskEither.of({}));
+const userEycaCardModelMock = {
+  findLastVersionByModelId: findLastVersionEycaByModelIdMock,
+  upsert: upsertMock
+};
+const checkUpdateCardIsRunningMock = jest
+  .fn()
+  .mockImplementation(() => taskEither.of(false));
+jest
+  .spyOn(orchUtils, "checkUpdateCardIsRunning")
+  .mockImplementation(checkUpdateCardIsRunningMock);
+
+const isEycaEligibleMock = jest.fn().mockImplementation(() => right(true));
+jest.spyOn(checks, "isEycaEligible").mockImplementation(isEycaEligibleMock);
+
+describe("StartEycaActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return an Internal Error if it is not possible to perform eyca eligibility check", async () => {
+    isEycaEligibleMock.mockImplementationOnce(() =>
+      left(new Error("Cannot recognize eligibility for EYCA"))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return an Internal Error if it is not possible to get CGN info", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot read CGN info"))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return Unauthorized the user is not eligible for EYCA", async () => {
+    isEycaEligibleMock.mockImplementationOnce(() => right(false));
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  });
+  it("should return Unauthorized if the user does not have a related CGN", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  });
+
+  it("should return Unauthorized if the user does not have an ACTIVATED CGN", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...anActivatedUserCgn,
+          status: { status: PendingStatusEnum.PENDING }
+        })
+      )
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  });
+
+  it("should return an Internal Error if it is not possible to get EYCA Card info", async () => {
+    findLastVersionEycaByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot read EYCA info"))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return a Conflict Error if an EYCA Card is already activated", async () => {
+    findLastVersionEycaByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some(aUserEycaCard))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorConflict");
+  });
+
+  it("should return an Internal Error if it is not possible to get EYCA Card activation status info", async () => {
+    findLastVersionEycaByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aUserEycaCard,
+          cardStatus: { status: PendingStatusEnum.PENDING }
+        })
+      )
+    );
+    mockGetStatus.mockImplementationOnce(() => Promise.reject("An error"));
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return an Internal Error if EYCA Card upsert fails", async () => {
+    findLastVersionEycaByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aUserEycaCard,
+          cardStatus: { status: PendingStatusEnum.PENDING }
+        })
+      )
+    );
+    upsertMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot upsert EYCA card"))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+  it("should return an Internal Error if EYCA Card activation's orchestrator start fails", async () => {
+    findLastVersionEycaByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({
+          ...aUserEycaCard,
+          cardStatus: { status: PendingStatusEnum.PENDING }
+        })
+      )
+    );
+    mockStartNew.mockImplementationOnce(() =>
+      Promise.reject(new Error("Cannot start orchestrator"))
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler(
+      // tslint:disable-next-line: no-console
+      { log: { error: console.log } } as any,
+      aFiscalCode
+    );
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should start a new orchestrator if there aren' t conflict on the same id", async () => {
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(mockStartNew).toBeCalledTimes(1);
+  });
+
+  it("should return an Accepted response if there is another orchestrator running with the same id", async () => {
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
+      fromLeft(ResponseSuccessAccepted())
+    );
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessAccepted");
+  });
+
+  it("should return an Response redirect to resource response if all steps succeed", async () => {
+    const startEycaActivationHandler = StartEycaActivationHandler(
+      userEycaCardModelMock as any,
+      userCgnModelMock as any
+    );
+    const response = await startEycaActivationHandler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessRedirectToResource");
+  });
+});

--- a/StartEycaActivation/__tests__/handler.test.ts
+++ b/StartEycaActivation/__tests__/handler.test.ts
@@ -6,11 +6,11 @@ import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { mockGetStatus, mockStartNew } from "../../__mocks__/durable-functions";
 import {
-  CardActivatedStatus,
+  CardActivated,
   StatusEnum as ActivatedStatusEnum
-} from "../../generated/definitions/CardActivatedStatus";
-import { StatusEnum as PendingStatusEnum } from "../../generated/definitions/CardPendingStatus";
-import { EycaCardActivatedStatus } from "../../generated/definitions/EycaCardActivatedStatus";
+} from "../../generated/definitions/CardActivated";
+import { StatusEnum as PendingStatusEnum } from "../../generated/definitions/CardPending";
+import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated";
 import { UserCgn } from "../../models/user_cgn";
 import { UserEycaCard } from "../../models/user_eyca_card";
 import * as checks from "../../utils/cgn_checks";
@@ -22,13 +22,13 @@ import { StartEycaActivationHandler } from "../handler";
 const aFiscalCode = "RODFDS89S10H501T" as FiscalCode;
 const anEycaCardNumber = "AAAAA" as NonEmptyString;
 
-const aUserCardActivatedStatus: CardActivatedStatus = {
+const aUserCardActivated: CardActivated = {
   activation_date: new Date(),
   expiration_date: addYears(new Date(), 2),
   status: ActivatedStatusEnum.ACTIVATED
 };
 
-const aUserEycaCardActivatedStatus: EycaCardActivatedStatus = {
+const aUserEycaCardActivated: EycaCardActivated = {
   activation_date: new Date(),
   card_number: anEycaCardNumber,
   expiration_date: addYears(new Date(), 2),
@@ -36,13 +36,13 @@ const aUserEycaCardActivatedStatus: EycaCardActivatedStatus = {
 };
 
 const anActivatedUserCgn: UserCgn = {
+  card: aUserCardActivated,
   fiscalCode: aFiscalCode,
-  id: "A_USER_CGN_ID" as NonEmptyString,
-  status: aUserCardActivatedStatus
+  id: "A_USER_CGN_ID" as NonEmptyString
 };
 
 const aUserEycaCard: UserEycaCard = {
-  cardStatus: aUserEycaCardActivatedStatus,
+  card: aUserEycaCardActivated,
   fiscalCode: aFiscalCode
 };
 
@@ -126,7 +126,7 @@ describe("StartEycaActivation", () => {
       taskEither.of(
         some({
           ...anActivatedUserCgn,
-          status: { status: PendingStatusEnum.PENDING }
+          card: { status: PendingStatusEnum.PENDING }
         })
       )
     );
@@ -167,7 +167,7 @@ describe("StartEycaActivation", () => {
       taskEither.of(
         some({
           ...aUserEycaCard,
-          cardStatus: { status: PendingStatusEnum.PENDING }
+          card: { status: PendingStatusEnum.PENDING }
         })
       )
     );
@@ -185,7 +185,7 @@ describe("StartEycaActivation", () => {
       taskEither.of(
         some({
           ...aUserEycaCard,
-          cardStatus: { status: PendingStatusEnum.PENDING }
+          card: { status: PendingStatusEnum.PENDING }
         })
       )
     );
@@ -204,7 +204,7 @@ describe("StartEycaActivation", () => {
       taskEither.of(
         some({
           ...aUserEycaCard,
-          cardStatus: { status: PendingStatusEnum.PENDING }
+          card: { status: PendingStatusEnum.PENDING }
         })
       )
     );

--- a/StartEycaActivation/function.json
+++ b/StartEycaActivation/function.json
@@ -1,0 +1,25 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/cgn/{fiscalcode}/eyca/activation",
+      "methods": [
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/StartEycaActivation/index.js"
+}

--- a/StartEycaActivation/handler.ts
+++ b/StartEycaActivation/handler.ts
@@ -139,11 +139,7 @@ export function StartEycaActivationHandler(
           () => taskEither.of(fiscalCode),
           userEycaCard =>
             // if an EYCA card is already in a final state we return Conflict
-            [
-              ActivatedStatusEnum.ACTIVATED.toString(),
-              ExpiredStatusEnum.EXPIRED.toString(),
-              RevokedStatusEnum.REVOKED.toString()
-            ].includes(userEycaCard.card.status)
+           !CardPending.is(userEycaCard.card)
               ? fromLeft(
                   ResponseErrorConflict(
                     `Cannot activate an EYCA card that is already ${userEycaCard.card.status}`

--- a/StartEycaActivation/handler.ts
+++ b/StartEycaActivation/handler.ts
@@ -148,7 +148,7 @@ export function StartEycaActivationHandler(
       )
       .chain(maybeUserEycaCard =>
         maybeUserEycaCard.foldL(
-          () => taskEither.of(fiscalCode),
+          () => taskEither.of(void 0),
           userEycaCard =>
             // if an EYCA card is already in a final state we return Conflict
             !CardPending.is(userEycaCard.card)
@@ -170,12 +170,12 @@ export function StartEycaActivationHandler(
                     fromNullable(maybeStatus).foldL(
                       // if orchestrator does not exists we assume that it expires its storage in TaskHub
                       // after 30 days so we can try to start a new activation process
-                      () => taskEither.of(fiscalCode),
+                      () => taskEither.of(void 0),
                       _ =>
                         // if orchestrator is running we return an Accepted Response
                         // otherwise we assume the orchestrator is in error or
                         // it has been canceled so we can try to start a new activation process
-                        mapOrchestratorStatus(_).map(() => fiscalCode)
+                        mapOrchestratorStatus(_).map(() => void 0)
                     )
                   )
         )

--- a/StartEycaActivation/index.ts
+++ b/StartEycaActivation/index.ts
@@ -1,0 +1,63 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+
+import { USER_CGN_COLLECTION_NAME, UserCgnModel } from "../models/user_cgn";
+import {
+  USER_EYCA_CARD_COLLECTION_NAME,
+  UserEycaCardModel
+} from "../models/user_eyca_card";
+import { getConfigOrThrow } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+import { StartEycaActivation } from "./handler";
+
+//
+//  CosmosDB initialization
+//
+
+const config = getConfigOrThrow();
+
+const userCgnsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_CGN_COLLECTION_NAME);
+
+const userCgnModel = new UserCgnModel(userCgnsContainer);
+
+const userEycaCardsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_EYCA_CARD_COLLECTION_NAME);
+
+const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+secureExpressApp(app);
+
+// Add express route
+app.post(
+  "/api/v1/cgn/:fiscalcode/eyca/activation",
+  StartEycaActivation(userEycaCardModel, userCgnModel)
+);
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/UpsertCgnStatus/__tests__/handler.test.ts
+++ b/UpsertCgnStatus/__tests__/handler.test.ts
@@ -55,10 +55,10 @@ const userCgnModelMock = {
   findLastVersionByModelId: findLastVersionByModelIdMock
 };
 
-const checkUpdateCgnIsRunningMock = jest.fn();
+const checkUpdateCardIsRunningMock = jest.fn();
 jest
-  .spyOn(orchUtils, "checkUpdateCgnIsRunning")
-  .mockImplementation(checkUpdateCgnIsRunningMock);
+  .spyOn(orchUtils, "checkUpdateCardIsRunning")
+  .mockImplementation(checkUpdateCardIsRunningMock);
 describe("UpsertCgnStatus", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -100,7 +100,7 @@ describe("UpsertCgnStatus", () => {
         some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
       )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       fromLeft(ResponseErrorInternal("Error"))
     );
     const upsertCgnStatusHandler = UpsertCgnStatusHandler(
@@ -120,7 +120,7 @@ describe("UpsertCgnStatus", () => {
         some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
       )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       fromLeft(ResponseSuccessAccepted())
     );
     const upsertCgnStatusHandler = UpsertCgnStatusHandler(
@@ -140,7 +140,7 @@ describe("UpsertCgnStatus", () => {
         some({ ...aRevokedUserCgn, status: aUserCardPendingStatus })
       )
     );
-    checkUpdateCgnIsRunningMock.mockImplementationOnce(() =>
+    checkUpdateCardIsRunningMock.mockImplementationOnce(() =>
       taskEither.of(false)
     );
     const upsertCgnStatusHandler = UpsertCgnStatusHandler(

--- a/UpsertCgnStatus/handler.ts
+++ b/UpsertCgnStatus/handler.ts
@@ -32,7 +32,7 @@ import { InstanceId } from "../generated/definitions/InstanceId";
 import { UserCgnModel } from "../models/user_cgn";
 import { OrchestratorInput } from "../UpdateCgnOrchestrator";
 import { makeUpdateCgnOrchestratorId } from "../utils/orchestrators";
-import { checkUpdateCgnIsRunning } from "../utils/orchestrators";
+import { checkUpdateCardIsRunning } from "../utils/orchestrators";
 
 type ErrorTypes =
   | IResponseErrorInternal
@@ -102,7 +102,7 @@ export function UpsertCgnStatusHandler(
         | IResponseSuccessAccepted
         | IResponseSuccessRedirectToResource<InstanceId, InstanceId>
       >(fromLeft, cardStatus =>
-        checkUpdateCgnIsRunning(client, fiscalCode, cardStatus).foldTaskEither<
+        checkUpdateCardIsRunning(client, fiscalCode, cardStatus).foldTaskEither<
           ErrorTypes,
           | IResponseSuccessAccepted
           | IResponseSuccessRedirectToResource<InstanceId, InstanceId>

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -85,6 +85,33 @@ paths:
           schema:
             $ref: "#/definitions/ProblemJson"
   
+  "/cgn/eyca/status/{fiscalcode}":
+    get:
+      summary: Get EYCA details Status
+      operationId: getEycaStatus
+      description: |
+        Get the EYCA status details by the provided fiscal code. 
+        In case of success the response could be one of:
+          - CardPending
+          - EycaCardActivated
+          - EycaCardRevoked
+          - EycaCardExpired
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "200":
+          description: EYCA details.
+          schema:
+            $ref: "#/definitions/EycaCard"
+        "401":
+          description: Wrong or missing function key.
+        "404":
+          description: No EYCA found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
+  
   "/cgn/{fiscalcode}/eyca/activation":
     post:
       operationId: startEycaActivation
@@ -116,32 +143,6 @@ paths:
         "409":
           description: |
             Cannot start a new activation because EYCA card is already activated
-  "/cgn/eyca/status/{fiscalcode}":
-    get:
-      summary: Get EYCA details Status
-      operationId: getEycaStatus
-      description: |
-        Get the EYCA status details by the provided fiscal code. 
-        In case of success the response could be one of:
-          - CardPending
-          - EycaCardActivated
-          - EycaCardRevoked
-          - EycaCardExpired
-      parameters:
-        - $ref: "#/parameters/FiscalCode"
-      responses:
-        "200":
-          description: EYCA details.
-          schema:
-            $ref: "#/definitions/EycaCard"
-        "401":
-          description: Wrong or missing function key.
-        "404":
-          description: No EYCA found.
-        "500":
-          description: Service unavailable.
-          schema:
-            $ref: "#/definitions/ProblemJson"
     get:
       operationId: getEycaActivation
       summary: |

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -143,6 +143,10 @@ paths:
         "409":
           description: |
             Cannot start a new activation because EYCA card is already activated
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
     get:
       operationId: getEycaActivation
       summary: |

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -84,6 +84,42 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+  
+  "/cgn/{fiscalcode}/eyca/activation":
+    post:
+      operationId: startEycaActivation
+      summary: |
+        Start a new Eyca activation process
+      description: |
+        Start an EYCA activation process related to a CGN
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "201":
+            description: Request created.
+            schema:
+              $ref: "#/definitions/InstanceId"
+            headers:
+              Location:
+                type: string
+                description: |-
+                  Location (URL) of created request resource.
+                  A GET request to this URL returns the request status and details.
+        "202":
+          description: Processing request.
+          schema:
+            $ref: "#/definitions/InstanceId"
+        "401":
+          description: Wrong or missing function key.
+        "403":
+          description: Forbidden.
+        "409":
+          description: |
+            Cannot start a new activation because EYCA card is already activated
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
   "/cgn/{fiscalcode}/activation":
     post:

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -142,6 +142,27 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+    get:
+      operationId: getEycaActivation
+      summary: |
+        Get EYCA activation process' status
+      description: |
+        Get informations about an EYCA activation process
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "200":
+            description: Cgn activation details.
+            schema:
+              $ref: "#/definitions/EycaActivationDetail"
+        "401":
+          description: Wrong or missing function key.
+        "404":
+          description: No CGN activation process found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
   "/cgn/{fiscalcode}/activation":
     post:
@@ -385,6 +406,24 @@ definitions:
         $ref: "#/definitions/Timestamp"
     required:
       - instance_id
+      - status
+
+  EycaActivationDetail:
+    type: object
+    properties:
+      status:
+        type: string
+        x-extensible-enum:
+          - PENDING
+          - RUNNING
+          - COMPLETED
+          - ERROR
+          - UNKNOWN
+      created_at:
+        $ref: "#/definitions/Timestamp"
+      last_updated_at:
+        $ref: "#/definitions/Timestamp"
+    required:
       - status
     
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "__mocks__",
     "dist",
     "node_modules",
+    "generated",
     "**/__tests__/*"
   ]
 }

--- a/utils/__tests__/orchestrators.test.ts
+++ b/utils/__tests__/orchestrators.test.ts
@@ -70,21 +70,21 @@ describe("isOrchestratorRunning", () => {
   });
 });
 
-describe("checkUpdateCgnIsRunning", () => {
+describe("checkUpdateCardIsRunning", () => {
   it("should return an accepted response if an orchestrator is running", async () => {
     mockGetOrchestratorStatus.mockImplementationOnce(() =>
       taskEither.of({
         runtimeStatus: df.OrchestrationRuntimeStatus.Running
       })
     );
-    const checkUpdateCgnIsRunningResult = await orchUtils
-      .checkUpdateCgnIsRunning(getClient as any, aFiscalCode, {
+    const checkUpdateCardIsRunningResult = await orchUtils
+      .checkUpdateCardIsRunning(getClient as any, aFiscalCode, {
         status: StatusEnum.PENDING
       })
       .run();
-    expect(isLeft(checkUpdateCgnIsRunningResult));
-    if (isLeft(checkUpdateCgnIsRunningResult)) {
-      expect(checkUpdateCgnIsRunningResult.value.kind).toEqual(
+    expect(isLeft(checkUpdateCardIsRunningResult));
+    if (isLeft(checkUpdateCardIsRunningResult)) {
+      expect(checkUpdateCardIsRunningResult.value.kind).toEqual(
         "IResponseSuccessAccepted"
       );
     }
@@ -94,14 +94,14 @@ describe("checkUpdateCgnIsRunning", () => {
     mockGetOrchestratorStatus.mockImplementationOnce(() =>
       fromLeft(new Error("Cannot recognize orchestrator status"))
     );
-    const checkUpdateCgnIsRunningResult = await orchUtils
-      .checkUpdateCgnIsRunning(getClient as any, aFiscalCode, {
+    const checkUpdateCardIsRunningResult = await orchUtils
+      .checkUpdateCardIsRunning(getClient as any, aFiscalCode, {
         status: StatusEnum.PENDING
       })
       .run();
-    expect(isLeft(checkUpdateCgnIsRunningResult));
-    if (isLeft(checkUpdateCgnIsRunningResult)) {
-      expect(checkUpdateCgnIsRunningResult.value.kind).toEqual(
+    expect(isLeft(checkUpdateCardIsRunningResult));
+    if (isLeft(checkUpdateCardIsRunningResult)) {
+      expect(checkUpdateCardIsRunningResult.value.kind).toEqual(
         "IResponseErrorInternal"
       );
     }

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -10,6 +10,7 @@ import {
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { ContinueEycaActivationInput } from "../ContinueEycaActivation";
 import { UserCgnModel } from "../models/user_cgn";
+import { UserEycaCardModel } from "../models/user_eyca_card";
 
 export const retrieveUserCgn = (
   userCgnModel: UserCgnModel,
@@ -25,6 +26,23 @@ export const retrieveUserCgn = (
         fromOption(
           ResponseErrorNotFound("Not Found", "User's CGN status not found")
         )(maybeUserCgn)
+      )
+    );
+
+export const retrieveUserEycaCard = (
+  userEycaCardModel: UserEycaCardModel,
+  fiscalCode: FiscalCode
+) =>
+  userEycaCardModel
+    .findLastVersionByModelId([fiscalCode])
+    .mapLeft<IResponseErrorInternal | IResponseErrorNotFound>(() =>
+      ResponseErrorInternal("Error trying to retrieve user's EYCA Card")
+    )
+    .chain(maybeUserEycaCard =>
+      fromEither(
+        fromOption(
+          ResponseErrorNotFound("Not Found", "User's EYCA Card not found")
+        )(maybeUserEycaCard)
       )
     );
 

--- a/utils/orchestrators.ts
+++ b/utils/orchestrators.ts
@@ -93,10 +93,7 @@ export const checkUpdateCardIsRunning = (
     cardStatus: string
   ) => string = makeUpdateCgnOrchestratorId
 ): TaskEither<CheckUpdateCardIsRunningErrorTypes, false> =>
-  isOrchestratorRunning(
-    client,
-    makeUpdateCgnOrchestratorId(fiscalCode, card.status)
-  )
+  isOrchestratorRunning(client, getOrchestratorId(fiscalCode, card.status))
     .foldTaskEither<CheckUpdateCardIsRunningErrorTypes, false>(
       err =>
         fromLeft(

--- a/utils/orchestrators.ts
+++ b/utils/orchestrators.ts
@@ -38,11 +38,13 @@ export const makeUpdateCgnOrchestratorId = (
 ) => `${fiscalCode}-UPDCGN-${cardStatus}`;
 
 /**
- * The identifier for StartEligibilityCheckOrchestrator
+ * The identifier for an EYCA related orchestrator
  * @param fiscalCode the id of the requesting user
  */
-export const makeEycaActivationOrchestratorId = (fiscalCode: FiscalCode) =>
-  `${fiscalCode}-EYCA-ACT`;
+export const makeEycaOrchestratorId = (
+  fiscalCode: FiscalCode,
+  cardStatus: string
+) => `${fiscalCode}-EYCA-${cardStatus}`;
 
 export const getOrchestratorStatus = (
   client: DurableOrchestrationClient,
@@ -75,27 +77,31 @@ const cgnStatuses: ReadonlyArray<string> = [
   CardPendingStatusEnum.PENDING.toString()
 ];
 
-export type CheckUpdateCgnIsRunningErrorTypes =
+export type CheckUpdateCardIsRunningErrorTypes =
   | IResponseErrorInternal
   | IResponseSuccessAccepted
   | IResponseErrorConflict;
 /**
- * Check if the current user has a pending cgn status update process.
+ * Check if the current user has a pending card status update process.
  */
-export const checkUpdateCgnIsRunning = (
+export const checkUpdateCardIsRunning = (
   client: DurableOrchestrationClient,
   fiscalCode: FiscalCode,
-  cardStatus: CardStatus
-): TaskEither<CheckUpdateCgnIsRunningErrorTypes, false> =>
+  cardStatus: CardStatus,
+  getOrchestratorId: (
+    fiscalCode: FiscalCode,
+    cardStatus: string
+  ) => string = makeUpdateCgnOrchestratorId
+): TaskEither<CheckUpdateCardIsRunningErrorTypes, false> =>
   isOrchestratorRunning(
     client,
-    makeUpdateCgnOrchestratorId(fiscalCode, cardStatus.status)
+    getOrchestratorId(fiscalCode, cardStatus.status)
   )
-    .foldTaskEither<CheckUpdateCgnIsRunningErrorTypes, false>(
+    .foldTaskEither<CheckUpdateCardIsRunningErrorTypes, false>(
       err =>
         fromLeft(
           ResponseErrorInternal(
-            `Error checking UpdateCgnOrchestrator: ${err.message}`
+            `Error checking UpdateCardOrchestrator: ${err.message}`
           )
         ),
       ({ isRunning }) =>
@@ -114,8 +120,8 @@ export const checkUpdateCgnIsRunning = (
         otherStatuses.map(status =>
           isOrchestratorRunning(
             client,
-            makeUpdateCgnOrchestratorId(fiscalCode, status)
-          ).foldTaskEither<CheckUpdateCgnIsRunningErrorTypes, false>(
+            getOrchestratorId(fiscalCode, status)
+          ).foldTaskEither<CheckUpdateCardIsRunningErrorTypes, false>(
             err =>
               fromLeft(
                 ResponseErrorInternal(


### PR DESCRIPTION
#### List of Changes
- Add `startEycaActivation` API
- Refactor orchestrator utilities in order to check concurrent running orchestrators both for EYCA Card and CGN

#### Motivation and Context
While a citizen requests for a CGN and he's between 18 up to 30 years old, he wants also activate an EYCA card ( CGN and EYCA are co-badged ), but in case of something goes wrong in EYCA activation, it must be possible to call directly EYCA activation from APP ( user retries ). Please Note that an EYCA activation process could not start if the user does not have already an `ACTIVATED` CGN.

#### How Has This Been Tested?
It has been tested by performing unit tests and integration test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.