### PR TITLE
[#176924340] Add GetEycaActivation status API

### DIFF
--- a/GetEycaActivation/__tests__/handler.test.ts
+++ b/GetEycaActivation/__tests__/handler.test.ts
@@ -1,0 +1,250 @@
+/* tslint:disable: no-any */
+import * as date_fns from "date-fns";
+import { OrchestrationRuntimeStatus } from "durable-functions/lib/src/classes";
+import { some } from "fp-ts/lib/Option";
+import { none } from "fp-ts/lib/Option";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { now } from "../../__mocks__/mock";
+import { StatusEnum as ActivatedStatusEnum } from "../../generated/definitions/CardActivated";
+import {
+  CardPending,
+  StatusEnum as PendingStatusEnum
+} from "../../generated/definitions/CardPending";
+import { StatusEnum } from "../../generated/definitions/CgnActivationDetail";
+import { EycaActivationDetail } from "../../generated/definitions/EycaActivationDetail";
+import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated";
+import { UserEycaCard } from "../../models/user_eyca_card";
+import * as orchUtils from "../../utils/orchestrators";
+import { GetEycaActivationHandler } from "../handler";
+
+const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
+const aCardNumber = "AAAAA" as NonEmptyString;
+
+const anInstanceId = {
+  id: orchUtils.makeUpdateCgnOrchestratorId(
+    aFiscalCode,
+    "ACTIVATED"
+  ) as NonEmptyString
+};
+const aCompletedResponse: EycaActivationDetail = {
+  status: StatusEnum.COMPLETED
+};
+const aPendingEycaCard: CardPending = {
+  status: PendingStatusEnum.PENDING
+};
+
+const anActivatedEyca: EycaCardActivated = {
+  activation_date: now,
+  card_number: aCardNumber,
+  expiration_date: date_fns.addDays(now, 10),
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const aUserEycaCard: UserEycaCard = {
+  card: aPendingEycaCard,
+  fiscalCode: aFiscalCode
+};
+
+const findLastVersionByModelIdMock = jest
+  .fn()
+  .mockImplementation(() =>
+    taskEither.of(some({ ...aUserEycaCard, card: anActivatedEyca }))
+  );
+const userEycaCardModelMock = {
+  findLastVersionByModelId: findLastVersionByModelIdMock
+};
+
+const getOrchestratorStatusMock = jest
+  .fn()
+  .mockImplementation((_, __) =>
+    taskEither.of({ instanceId: anInstanceId, customStatus: "COMPLETED" })
+  );
+jest
+  .spyOn(orchUtils, "getOrchestratorStatus")
+  .mockImplementation(getOrchestratorStatusMock);
+
+describe("GetEycaActivationHandler", () => {
+  it("should return success with ERROR status if orchestrator status is Failed", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Failed
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.ERROR
+      });
+    }
+  });
+
+  it("should return success with RUNNING status if orchestrator status is Running", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Running
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.RUNNING
+      });
+    }
+  });
+  it("should return success if an orchestrator's custom status is UPDATED", async () => {
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success if an orchestrator's custom status is COMPLETED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({ instanceId: anInstanceId, customStatus: "COMPLETED" })
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return an internal error if there are errors to retrieve a UserCgn", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Query Error"))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return Not found if infos about orchestrator status and UserCgn are missing", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorNotFound");
+  });
+
+  it("should return Not found if infos about orchestrator status are not recognized and UserCgn are missing", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Canceled
+      })
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorNotFound");
+  });
+
+  it("should return success with COMPLETED status if orchestrator infos are missing and userCgn is already activated", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success with COMPLETED status if orchestrator check status raise an error but userCgn is already activated", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot recognize orchestrator status"))
+    );
+
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual(aCompletedResponse);
+    }
+  });
+
+  it("should return success with PENDING status if orchestrator infos are missing and userCgn is PENDING", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of(undefined)
+    );
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard }))
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.PENDING
+      });
+    }
+  });
+
+  it("should return success with COMPLETED status if the orchestrator is terminated and userCgn is ACTIVATED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Terminated
+      })
+    );
+
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.COMPLETED
+      });
+    }
+  });
+
+  it("should return success with COMPLETED status if custom status is UPDATED and userCgn is ACTIVATED", async () => {
+    getOrchestratorStatusMock.mockImplementationOnce(() =>
+      taskEither.of({
+        customStatus: "UPDATED",
+        instanceId: anInstanceId,
+        runtimeStatus: OrchestrationRuntimeStatus.Running
+      })
+    );
+    const handler = GetEycaActivationHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aCompletedResponse,
+        status: StatusEnum.COMPLETED
+      });
+    }
+  });
+});

--- a/GetEycaActivation/__tests__/handler.test.ts
+++ b/GetEycaActivation/__tests__/handler.test.ts
@@ -66,6 +66,9 @@ jest
   .mockImplementation(getOrchestratorStatusMock);
 
 describe("GetEycaActivationHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("should return success with ERROR status if orchestrator status is Failed", async () => {
     getOrchestratorStatusMock.mockImplementationOnce(() =>
       taskEither.of({

--- a/GetEycaActivation/function.json
+++ b/GetEycaActivation/function.json
@@ -14,6 +14,11 @@
       "type": "http",
       "direction": "out",
       "name": "res"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
     }
   ],
   "scriptFile": "../dist/GetEycaActivation/index.js"

--- a/GetEycaActivation/function.json
+++ b/GetEycaActivation/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/cgn/{fiscalcode}/eyca/activation",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetEycaActivation/index.js"
+}

--- a/GetEycaActivation/handler.ts
+++ b/GetEycaActivation/handler.ts
@@ -6,7 +6,7 @@ import { DurableOrchestrationStatus } from "durable-functions/lib/src/classes";
 import { Either, left, right } from "fp-ts/lib/Either";
 import { identity } from "fp-ts/lib/function";
 import { fromNullable } from "fp-ts/lib/Option";
-import { fromEither, taskEither, TaskEither } from "fp-ts/lib/TaskEither";
+import { fromEither, taskEither } from "fp-ts/lib/TaskEither";
 import { fromLeft } from "fp-ts/lib/TaskEither";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
@@ -18,8 +18,6 @@ import {
   IResponseErrorInternal,
   IResponseErrorNotFound,
   IResponseSuccessJson,
-  ResponseErrorInternal,
-  ResponseErrorNotFound,
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import { FiscalCode } from "italia-ts-commons/lib/strings";

--- a/GetEycaActivation/handler.ts
+++ b/GetEycaActivation/handler.ts
@@ -1,0 +1,142 @@
+import * as express from "express";
+
+import { Context } from "@azure/functions";
+import * as df from "durable-functions";
+import { DurableOrchestrationStatus } from "durable-functions/lib/src/classes";
+import { identity } from "fp-ts/lib/function";
+import { fromNullable } from "fp-ts/lib/Option";
+import { taskEither, TaskEither } from "fp-ts/lib/TaskEither";
+import { fromLeft } from "fp-ts/lib/TaskEither";
+import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
+import {
+  withRequestMiddlewares,
+  wrapRequestHandler
+} from "io-functions-commons/dist/src/utils/request_middleware";
+import {
+  IResponseErrorInternal,
+  IResponseErrorNotFound,
+  IResponseSuccessJson,
+  ResponseErrorInternal,
+  ResponseErrorNotFound,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { CardActivated } from "../generated/definitions/CardActivated";
+import { StatusEnum } from "../generated/definitions/CgnActivationDetail";
+import { EycaActivationDetail } from "../generated/definitions/EycaActivationDetail";
+import { UserEycaCardModel } from "../models/user_eyca_card";
+import { retrieveUserEycaCard } from "../utils/models";
+import {
+  getOrchestratorStatus,
+  makeEycaOrchestratorId
+} from "../utils/orchestrators";
+
+type ResponseTypes =
+  | IResponseSuccessJson<EycaActivationDetail>
+  | IResponseErrorNotFound
+  | IResponseErrorInternal;
+
+type IGetEycaActivationHandler = (
+  context: Context,
+  fiscalCode: FiscalCode
+) => Promise<ResponseTypes>;
+
+const mapOrchestratorStatus = (
+  orchestratorStatus: DurableOrchestrationStatus
+): TaskEither<IResponseErrorNotFound, StatusEnum> => {
+  if (
+    orchestratorStatus.customStatus === "UPDATED" ||
+    orchestratorStatus.customStatus === "COMPLETED"
+  ) {
+    return taskEither.of(StatusEnum.COMPLETED);
+  }
+  switch (orchestratorStatus.runtimeStatus) {
+    case df.OrchestrationRuntimeStatus.Pending:
+      return taskEither.of(StatusEnum.PENDING);
+    case df.OrchestrationRuntimeStatus.Running:
+    case df.OrchestrationRuntimeStatus.ContinuedAsNew:
+      return taskEither.of(StatusEnum.RUNNING);
+    case df.OrchestrationRuntimeStatus.Failed:
+      return taskEither.of(StatusEnum.ERROR);
+    case df.OrchestrationRuntimeStatus.Completed:
+      return taskEither.of(StatusEnum.COMPLETED);
+    default:
+      return fromLeft(
+        ResponseErrorNotFound("Not found", "Cannot recognize status")
+      );
+  }
+};
+
+export function GetEycaActivationHandler(
+  userEycaCardModel: UserEycaCardModel
+): IGetEycaActivationHandler {
+  return async (context, fiscalCode) => {
+    const client = df.getClient(context);
+    const orchestratorId = makeEycaOrchestratorId(
+      fiscalCode,
+      StatusEnum.PENDING
+    );
+    // first check if an activation process is running
+    return retrieveUserEycaCard(userEycaCardModel, fiscalCode)
+      .map(_ => _.card)
+      .chain(eycaCard =>
+        getOrchestratorStatus(client, orchestratorId)
+          .mapLeft<IResponseErrorInternal | IResponseErrorNotFound>(() =>
+            ResponseErrorInternal("Cannot retrieve activation status")
+          )
+          .chain<EycaActivationDetail>(maybeOrchestrationStatus =>
+            fromNullable(maybeOrchestrationStatus).foldL(
+              () =>
+                fromLeft(
+                  ResponseErrorNotFound(
+                    "Cannot find any activation process",
+                    "Orchestrator instance not found"
+                  )
+                ),
+              orchestrationStatus =>
+                // now try to map orchestrator status
+                mapOrchestratorStatus(orchestrationStatus).map(_ => ({
+                  created_at: orchestrationStatus.createdTime,
+                  last_updated_at: orchestrationStatus.lastUpdatedTime,
+                  status: _
+                }))
+            )
+          )
+          .foldTaskEither<
+            IResponseErrorInternal | IResponseErrorNotFound,
+            EycaActivationDetail
+          >(
+            () =>
+              // It's not possible to map any activation status
+              // check for EYCA CArd status on cosmos
+              taskEither
+                .of<
+                  IResponseErrorInternal | IResponseErrorNotFound,
+                  StatusEnum
+                >(
+                  CardActivated.is(eycaCard)
+                    ? StatusEnum.COMPLETED
+                    : StatusEnum.PENDING
+                )
+                .map(_ => ({ status: _ })),
+            activationDetail => taskEither.of(activationDetail)
+          )
+      )
+      .fold<ResponseTypes>(identity, _ => ResponseSuccessJson(_))
+      .run();
+  };
+}
+
+export function GetEycaActivation(
+  userEycaCardModel: UserEycaCardModel
+): express.RequestHandler {
+  const handler = GetEycaActivationHandler(userEycaCardModel);
+
+  const middlewaresWrap = withRequestMiddlewares(
+    ContextMiddleware(),
+    RequiredParamMiddleware("fiscalcode", FiscalCode)
+  );
+
+  return wrapRequestHandler(middlewaresWrap(handler));
+}

--- a/GetEycaActivation/handler.ts
+++ b/GetEycaActivation/handler.ts
@@ -3,9 +3,10 @@ import * as express from "express";
 import { Context } from "@azure/functions";
 import * as df from "durable-functions";
 import { DurableOrchestrationStatus } from "durable-functions/lib/src/classes";
+import { Either, left, right } from "fp-ts/lib/Either";
 import { identity } from "fp-ts/lib/function";
 import { fromNullable } from "fp-ts/lib/Option";
-import { taskEither, TaskEither } from "fp-ts/lib/TaskEither";
+import { fromEither, taskEither, TaskEither } from "fp-ts/lib/TaskEither";
 import { fromLeft } from "fp-ts/lib/TaskEither";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
@@ -44,25 +45,25 @@ type IGetEycaActivationHandler = (
 
 const mapOrchestratorStatus = (
   orchestratorStatus: DurableOrchestrationStatus
-): TaskEither<IResponseErrorNotFound, StatusEnum> => {
+): Either<IResponseErrorNotFound, StatusEnum> => {
   if (
     orchestratorStatus.customStatus === "UPDATED" ||
     orchestratorStatus.customStatus === "COMPLETED"
   ) {
-    return taskEither.of(StatusEnum.COMPLETED);
+    return right(StatusEnum.COMPLETED);
   }
   switch (orchestratorStatus.runtimeStatus) {
     case df.OrchestrationRuntimeStatus.Pending:
-      return taskEither.of(StatusEnum.PENDING);
+      return right(StatusEnum.PENDING);
     case df.OrchestrationRuntimeStatus.Running:
     case df.OrchestrationRuntimeStatus.ContinuedAsNew:
-      return taskEither.of(StatusEnum.RUNNING);
+      return right(StatusEnum.RUNNING);
     case df.OrchestrationRuntimeStatus.Failed:
-      return taskEither.of(StatusEnum.ERROR);
+      return right(StatusEnum.ERROR);
     case df.OrchestrationRuntimeStatus.Completed:
-      return taskEither.of(StatusEnum.COMPLETED);
+      return right(StatusEnum.COMPLETED);
     default:
-      return fromLeft(
+      return left(
         ResponseErrorNotFound("Not found", "Cannot recognize status")
       );
   }
@@ -96,11 +97,13 @@ export function GetEycaActivationHandler(
                 ),
               orchestrationStatus =>
                 // now try to map orchestrator status
-                mapOrchestratorStatus(orchestrationStatus).map(_ => ({
-                  created_at: orchestrationStatus.createdTime,
-                  last_updated_at: orchestrationStatus.lastUpdatedTime,
-                  status: _
-                }))
+                fromEither(mapOrchestratorStatus(orchestrationStatus)).map(
+                  _ => ({
+                    created_at: orchestrationStatus.createdTime,
+                    last_updated_at: orchestrationStatus.lastUpdatedTime,
+                    status: _
+                  })
+                )
             )
           )
           .foldTaskEither<
@@ -109,7 +112,7 @@ export function GetEycaActivationHandler(
           >(
             () =>
               // It's not possible to map any activation status
-              // check for EYCA CArd status on cosmos
+              // check for EYCA Card status on cosmos
               taskEither
                 .of<
                   IResponseErrorInternal | IResponseErrorNotFound,

--- a/GetEycaActivation/index.ts
+++ b/GetEycaActivation/index.ts
@@ -1,0 +1,56 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+
+import {
+  USER_EYCA_CARD_COLLECTION_NAME,
+  UserEycaCardModel
+} from "../models/user_eyca_card";
+import { getConfigOrThrow } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+import { GetEycaActivation } from "./handler";
+
+//
+//  CosmosDB initialization
+//
+
+const config = getConfigOrThrow();
+
+const userEycaCardsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_EYCA_CARD_COLLECTION_NAME);
+
+const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+secureExpressApp(app);
+
+// Add express route
+app.get(
+  "/api/v1/cgn/:fiscalcode/eyca/activation",
+  GetEycaActivation(userEycaCardModel)
+);
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -120,6 +120,27 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+    get:
+      operationId: getEycaActivation
+      summary: |
+        Get EYCA activation process' status
+      description: |
+        Get informations about an EYCA activation process
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "200":
+            description: Cgn activation details.
+            schema:
+              $ref: "#/definitions/EycaActivationDetail"
+        "401":
+          description: Wrong or missing function key.
+        "404":
+          description: No CGN activation process found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
   "/cgn/{fiscalcode}/activation":
     post:
@@ -363,6 +384,24 @@ definitions:
         $ref: "#/definitions/Timestamp"
     required:
       - instance_id
+      - status
+
+  EycaActivationDetail:
+    type: object
+    properties:
+      status:
+        type: string
+        x-extensible-enum:
+          - PENDING
+          - RUNNING
+          - COMPLETED
+          - ERROR
+          - UNKNOWN
+      created_at:
+        $ref: "#/definitions/Timestamp"
+      last_updated_at:
+        $ref: "#/definitions/Timestamp"
+    required:
       - status
     
 

--- a/utils/models.ts
+++ b/utils/models.ts
@@ -10,6 +10,7 @@ import {
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { ContinueEycaActivationInput } from "../ContinueEycaActivation";
 import { UserCgnModel } from "../models/user_cgn";
+import { UserEycaCardModel } from "../models/user_eyca_card";
 
 export const retrieveUserCgn = (
   userCgnModel: UserCgnModel,
@@ -25,6 +26,23 @@ export const retrieveUserCgn = (
         fromOption(
           ResponseErrorNotFound("Not Found", "User's CGN status not found")
         )(maybeUserCgn)
+      )
+    );
+
+export const retrieveUserEycaCard = (
+  userEycaCardModel: UserEycaCardModel,
+  fiscalCode: FiscalCode
+) =>
+  userEycaCardModel
+    .findLastVersionByModelId([fiscalCode])
+    .mapLeft<IResponseErrorInternal | IResponseErrorNotFound>(() =>
+      ResponseErrorInternal("Error trying to retrieve user's EYCA Card")
+    )
+    .chain(maybeUserEycaCard =>
+      fromEither(
+        fromOption(
+          ResponseErrorNotFound("Not Found", "User's EYCA Card not found")
+        )(maybeUserEycaCard)
       )
     );
 


### PR DESCRIPTION
#### List of Changes
- Add `getEycaActivation` API
- Add tests

#### Motivation and Context
While a citizen requests for a CGN and he's between 18 up to 30 years old, he wants also activate an EYCA card ( CGN and EYCA are co-badged ). Since an EYCA activation is an async process we must provide an API that could provide informations about EYCA activation status.

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.