### PR TITLE
Added '@pagopa/' to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-functions-cgn",
+  "name": "@pagopa/io-functions-cgn",
   "description": "",
   "author": "IO team",
   "repository": "https://github.com/pagoPA/io-functions-template",


### PR DESCRIPTION
In order to generate a correct client SDK, added @pagopa/ to the package name