### PR TITLE
Add Client SDK Generation

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -28,10 +28,16 @@ pool:
 
 resources:
   repositories:
-    - repository: pagopaCommons
+    - repository: pagopaCommonsLegacy
       type: github
       name: pagopa/azure-pipeline-templates
       ref: refs/tags/v4
+      endpoint: 'pagopa'
+  
+    - repository: pagopaCommons
+      type: github
+      name: pagopa/azure-pipeline-templates
+      ref: refs/tags/v12
       endpoint: 'pagopa'
 
 stages:
@@ -58,7 +64,7 @@ stages:
       - job: make_release
         steps:
         - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-          - template: templates/node-github-release/template.yaml@pagopaCommons 
+          - template: templates/node-github-release/template.yaml@pagopaCommonsLegacy 
             parameters:
               semver: '${{ parameters.RELEASE_SEMVER }}'
               gitEmail: $(GIT_EMAIL)
@@ -140,7 +146,7 @@ stages:
     jobs:
       - job: 'do_healthcheck'       
         steps:  
-          - template: templates/rest-healthcheck/template.yaml@pagopaCommons 
+          - template: templates/rest-healthcheck/template.yaml@pagopaCommonsLegacy 
             parameters:
               azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
               appName: '$(PRODUCTION_APP_NAME)'
@@ -166,3 +172,18 @@ stages:
               sourceSlot: staging
               swapWithProduction: true
             displayName: Swap with production slot
+
+
+  # Publish client SDK to NPM
+  - stage: PublishClientSDKtoNPM
+    dependsOn: Release
+    pool:
+      vmImage: 'ubuntu-latest'
+    jobs:
+      - job: publish_SDK   
+        steps:
+        # Template for generating and deploying client SDk to NPM
+        - template: templates/client-sdk-publish/template.yaml@pagopaCommons
+          parameters:
+            openapiSpecPath: 'openapi/index.yaml'
+            generatorPackageName: italia-utils           


### PR DESCRIPTION
Use _italia-utils_ as client SDK generation, in order to publish client SDH package to NPM