### PR TITLE
[#177017837] Added new api for retrieving eyca card

### DIFF
--- a/GetEycaStatus/__tests__/handler.test.ts
+++ b/GetEycaStatus/__tests__/handler.test.ts
@@ -1,0 +1,101 @@
+/* tslint:disable: no-any */
+
+import * as date_fns from "date-fns";
+import { some } from "fp-ts/lib/Option";
+import { none } from "fp-ts/lib/Option";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { cgnActivatedDates, now } from "../../__mocks__/mock";
+import { StatusEnum as ActivatedStatusEnum } from "../../generated/definitions/CardActivated";
+import {
+  CardPending,
+  StatusEnum as PendingStatusEnum
+} from "../../generated/definitions/CardPending";
+import { StatusEnum as RevokedStatusEnum } from "../../generated/definitions/CardRevoked";
+import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated";
+import { EycaCardRevoked } from "../../generated/definitions/EycaCardRevoked";
+import { UserEycaCard, UserEycaCardModel } from "../../models/user_eyca_card";
+import { GetEycaStatusHandler } from "../handler";
+
+const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
+const aUserEycaCardNumber = "AN_ID" as NonEmptyString;
+
+const aPendingEycaCard: CardPending = {
+  status: PendingStatusEnum.PENDING
+};
+
+const aUserEycaCard: UserEycaCard = {
+  card: aPendingEycaCard,
+  fiscalCode: aFiscalCode
+};
+
+const aRevokedEycaCard: EycaCardRevoked = {
+  ...cgnActivatedDates,
+  card_number: aUserEycaCardNumber,
+  revocation_date: now,
+  revocation_reason: "A motivation" as NonEmptyString,
+  status: RevokedStatusEnum.REVOKED
+};
+
+const findLastVersionByModelIdMock = jest
+  .fn()
+  .mockImplementation(() => taskEither.of(some(aUserEycaCard)));
+const userEycaCardModelMock = {
+  findLastVersionByModelId: findLastVersionByModelIdMock
+};
+
+const anActivatedEycaCard: EycaCardActivated = {
+  activation_date: now,
+  card_number: aUserEycaCardNumber,
+  expiration_date: date_fns.addDays(now, 10),
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const successImpl = async (userEycaCard: UserEycaCard) => {
+  const handler = GetEycaStatusHandler(userEycaCardModelMock as any);
+  const response = await handler({} as any, aFiscalCode);
+  expect(response.kind).toBe("IResponseSuccessJson");
+  if (response.kind === "IResponseSuccessJson") {
+    expect(response.value).toEqual({
+      ...userEycaCard.card
+    });
+  }
+};
+describe("GetEycaCardStatusHandler", () => {
+  it("should return an internal error when a query error occurs", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Query Error"))
+    );
+    const handler = GetEycaStatusHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+
+  it("should return not found if no userEycaCard is found", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const handler = GetEycaStatusHandler(userEycaCardModelMock as any);
+    const response = await handler({} as any, aFiscalCode);
+    expect(response.kind).toBe("IResponseErrorNotFound");
+  });
+
+  it("should return success if a pending userEycaCard is found", async () => {
+    await successImpl(aUserEycaCard);
+  });
+
+  it("should return success if a revoked userEycaCard is found", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard, card: aRevokedEycaCard }))
+    );
+    await successImpl({ ...aUserEycaCard, card: aRevokedEycaCard });
+  });
+
+  it("should return success if an activated userEycaCard is found", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some({ ...aUserEycaCard, card: anActivatedEycaCard }))
+    );
+    await successImpl({ ...aUserEycaCard, card: anActivatedEycaCard });
+  });
+});

--- a/GetEycaStatus/function.json
+++ b/GetEycaStatus/function.json
@@ -5,7 +5,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "route": "api/v1/cgn/status/{fiscalcode}",
+      "route": "api/v1/cgn/eyca/status/{fiscalcode}",
       "methods": [
         "get"
       ]

--- a/GetEycaStatus/function.json
+++ b/GetEycaStatus/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/cgn/status/{fiscalcode}",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetEycaStatus/index.js"
+}

--- a/GetEycaStatus/handler.ts
+++ b/GetEycaStatus/handler.ts
@@ -19,46 +19,52 @@ import {
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
-import { Card } from "../generated/definitions/Card";
-import { UserCgnModel } from "../models/user_cgn";
+
+import { EycaCard } from "../generated/definitions/EycaCard";
+import { UserEycaCardModel } from "../models/user_eyca_card";
 
 type ResponseTypes =
-  | IResponseSuccessJson<Card>
+  | IResponseSuccessJson<EycaCard>
   | IResponseErrorNotFound
   | IResponseErrorInternal;
 
-type IGetCgnStatusHandler = (
+type IGetEycaStatusHandler = (
   context: Context,
   fiscalCode: FiscalCode
 ) => Promise<ResponseTypes>;
 
-export function GetCgnStatusHandler(
-  userCgnModel: UserCgnModel
-): IGetCgnStatusHandler {
+export function GetEycaStatusHandler(
+  userEycaCardModel: UserEycaCardModel
+): IGetEycaStatusHandler {
   return async (_, fiscalCode) => {
-    return userCgnModel
+    return userEycaCardModel
       .findLastVersionByModelId([fiscalCode])
       .mapLeft<IResponseErrorInternal | IResponseErrorNotFound>(() =>
-        ResponseErrorInternal("Error trying to retrieve user's CGN status")
-      )
-      .chain(maybeUserCgn =>
-        fromEither(
-          fromOption(
-            ResponseErrorNotFound("Not Found", "User's CGN status not found")
-          )(maybeUserCgn)
+        ResponseErrorInternal(
+          "Error trying to retrieve user's EYCA Card status"
         )
       )
-      .fold<ResponseTypes>(identity, userCgn =>
-        ResponseSuccessJson(userCgn.card)
+      .chain(maybeUserEycaCard =>
+        fromEither(
+          fromOption(
+            ResponseErrorNotFound(
+              "Not Found",
+              "User's EYCA Card status not found"
+            )
+          )(maybeUserEycaCard)
+        )
+      )
+      .fold<ResponseTypes>(identity, userEycaCard =>
+        ResponseSuccessJson(userEycaCard.card)
       )
       .run();
   };
 }
 
-export function GetCgnStatus(
-  userCgnModel: UserCgnModel
+export function GetEycaStatus(
+  userEycaCardModel: UserEycaCardModel
 ): express.RequestHandler {
-  const handler = GetCgnStatusHandler(userCgnModel);
+  const handler = GetEycaStatusHandler(userEycaCardModel);
 
   const middlewaresWrap = withRequestMiddlewares(
     ContextMiddleware(),

--- a/GetEycaStatus/index.ts
+++ b/GetEycaStatus/index.ts
@@ -1,0 +1,56 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+
+import {
+  USER_EYCA_CARD_COLLECTION_NAME,
+  UserEycaCardModel
+} from "../models/user_eyca_card";
+import { getConfigOrThrow } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+import { GetEycaStatus } from "./handler";
+
+//
+//  CosmosDB initialization
+//
+
+const config = getConfigOrThrow();
+
+const userEycaCardsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_EYCA_CARD_COLLECTION_NAME);
+
+const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+secureExpressApp(app);
+
+// Add express route
+app.get(
+  "/api/v1/cgn/eyca/status/:fiscalcode",
+  GetEycaStatus(userEycaCardModel)
+);
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -84,6 +84,33 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+  
+  "/cgn/eyca/status/{fiscalcode}":
+    get:
+      summary: Get EYCA details Status
+      operationId: getEycaStatus
+      description: |
+        Get the EYCA status details by the provided fiscal code. 
+        In case of success the response could be one of:
+          - CardPending
+          - EycaCardActivated
+          - EycaCardRevoked
+          - EycaCardExpired
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "200":
+          description: EYCA details.
+          schema:
+            $ref: "#/definitions/EycaCard"
+        "401":
+          description: Wrong or missing function key.
+        "404":
+          description: No EYCA found.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 
   "/cgn/{fiscalcode}/activation":
     post:


### PR DESCRIPTION
#### List of Changes
- Add `getEycaStatus` API
- Add tests

#### Motivation and Context
While a citizen requests for a CGN and he's between 18 up to 30 years old, he wants also activate an EYCA card ( CGN and EYCA are co-badged ). We need to provide an API that could return detailed information about an EYCA Card.

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.