### PR TITLE
[#175761529] Add Generate OTP API specs

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -229,6 +229,30 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+
+  "/cgn/otp/{fiscalcode}":
+    post:
+      operationId: generateOtp
+      summary: |
+        Generate a new Otp related to a CGN
+      description: |
+        Generate a new Otp used to discount an online purchase
+        through a valid CGN
+      parameters:
+        - $ref: "#/parameters/FiscalCode"
+      responses:
+        "200":
+            description: Otp generated.
+            schema:
+              $ref: "#/definitions/Otp"
+        "401":
+          description: Wrong or missing function key.
+        "403":
+          description: Forbidden.
+        "500":
+          description: Service unavailable.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 consumes:
   - application/json
 produces:
@@ -437,3 +461,21 @@ definitions:
         $ref: "#/definitions/Timestamp"
     required:
       - status
+
+  OtpCode:
+    description: The unique otp code that identifies can be use for discounts
+    type: string
+    pattern: "^[A-Z0-9]{9,13}$"
+  Otp:
+    type: object
+    properties:
+      code:
+        $ref: "#/definitions/OtpCode"
+      expires_at:
+        $ref: "#/definitions/Timestamp"
+      ttl:
+        type: number
+    required:
+      - code
+      - expires_at
+      - ttl

--- a/utils/cgnCode.ts
+++ b/utils/cgnCode.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 
 import { isLeft } from "fp-ts/lib/Either";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { OtpCode } from "../generated/definitions/OtpCode";
 
 // Note that we redeclare the alphabet and the length of the CGN here as a
 // double assurance that the implementation is correct and things will break
@@ -12,8 +13,13 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 export const ALPHABET = "ABCDEFGHILMNOPQRSTUVZ123456789";
 const ALPHABET_LEN = ALPHABET.length;
 
+export const OTP_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const OTP_ALPHABET_LEN = OTP_ALPHABET.length;
+
 // Youth Card codes have a length of 16 characthers
 export const BONUSCODE_LENGTH = 16;
+
+export const OTPCODE_LENGTH = 11;
 
 const asyncRandomBytes = promisify(randomBytes);
 
@@ -33,4 +39,22 @@ export async function genRandomCardCode(
     );
   }
   return cardCode.value;
+}
+
+/**
+ * Generates a new random OTP code
+ */
+export async function generateOtpCode(
+  getAsyncRandomBytes: typeof asyncRandomBytes = asyncRandomBytes
+): Promise<OtpCode> {
+  const randomBuffer = await getAsyncRandomBytes(OTPCODE_LENGTH);
+  const code = [...randomBuffer]
+    .map(b => OTP_ALPHABET[b % OTP_ALPHABET_LEN])
+    .join("");
+  const otpCode = OtpCode.decode(code);
+  if (isLeft(otpCode)) {
+    // this should never happen
+    throw Error(`FATAL: generateOtpCode generated invalid OTP code [${code}]`);
+  }
+  return otpCode.value;
 }


### PR DESCRIPTION
#### List of Changes
- Add `generateOtp` API Specs
- Add `generateOtpCode` utility method

#### Motivation and Context
Since a CGN could be used to obtain discounts over online's purchase, we must provide an API that could generate an OTP, to be used in the checkout phase through third-parties e-commerce portal. See this [story](https://www.pivotaltracker.com/story/show/175761529) for further informations.

#### How Has This Been Tested?
No tests needed

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.