### PR TITLE
[#177116930] Add EYCA expiration process

### DIFF
--- a/ExpireEycaActivity/__tests__/handler.test.ts
+++ b/ExpireEycaActivity/__tests__/handler.test.ts
@@ -1,0 +1,133 @@
+/* tslint:disable: no-any */
+import { none, some } from "fp-ts/lib/Option";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { toCosmosErrorResponse } from "io-functions-commons/dist/src/utils/cosmosdb_model";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { context } from "../../__mocks__/durable-functions";
+import { cgnActivatedDates } from "../../__mocks__/mock";
+import { StatusEnum as ActivatedStatusEnum } from "../../generated/definitions/CardActivated";
+import {
+  CardPending,
+  StatusEnum
+} from "../../generated/definitions/CardPending";
+
+import { StatusEnum as ExpiredStatusEnum } from "../../generated/definitions/CardExpired";
+import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated";
+import { CcdbNumber } from "../../generated/eyca-api/CcdbNumber";
+import { UserEycaCard } from "../../models/user_eyca_card";
+import { ActivityInput, getExpireEycaActivityHandler } from "../handler";
+
+const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
+
+const aUserEycaCardNumber = "X321-Y321-Z321-W321" as CcdbNumber;
+const anActivatedEycaCard: EycaCardActivated = {
+  ...cgnActivatedDates,
+  card_number: aUserEycaCardNumber,
+  status: ActivatedStatusEnum.ACTIVATED
+};
+
+const anActivatedUserEycaCard: UserEycaCard = {
+  card: anActivatedEycaCard,
+  fiscalCode: aFiscalCode
+};
+
+const aUserCardPending: CardPending = {
+  status: StatusEnum.PENDING
+};
+
+const findLastVersionByModelIdMock = jest.fn();
+const updateMock = jest.fn();
+
+const userCgnModelMock = {
+  findLastVersionByModelId: findLastVersionByModelIdMock,
+  update: updateMock
+};
+
+const anActivityInput: ActivityInput = {
+  fiscalCode: aFiscalCode
+};
+describe("ExpireEycaActivity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should return failure if an error occurs during User Eyca Card retrieve", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      fromLeft(toCosmosErrorResponse(new Error("query error")))
+    );
+    const expireEycaActivityHandler = getExpireEycaActivityHandler(
+      userCgnModelMock as any
+    );
+    const response = await expireEycaActivityHandler(context, anActivityInput);
+    expect(response.kind).toBe("FAILURE");
+    if (response.kind === "FAILURE") {
+      expect(response.reason).toBe(
+        "Cannot retrieve User EYCA Card for the provided fiscalCode"
+      );
+    }
+  });
+
+  it("should return failure if no User Eyca Card was found", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(none)
+    );
+    const expireEycaActivityHandler = getExpireEycaActivityHandler(
+      userCgnModelMock as any
+    );
+    const response = await expireEycaActivityHandler(context, anActivityInput);
+    expect(response.kind).toBe("FAILURE");
+    if (response.kind === "FAILURE") {
+      expect(response.reason).toBe(
+        "No User EYCA Card found for the provided fiscalCode"
+      );
+    }
+  });
+
+  it("should return failure if User Eyca Card is not Active", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some(aUserCardPending))
+    );
+    const expireEycaActivityHandler = getExpireEycaActivityHandler(
+      userCgnModelMock as any
+    );
+    const response = await expireEycaActivityHandler(context, anActivityInput);
+    expect(response.kind).toBe("FAILURE");
+    if (response.kind === "FAILURE") {
+      expect(response.reason).toBe(
+        "Cannot expire an EYCA Card that is not ACTIVATED"
+      );
+    }
+  });
+  it("should return failure if userCgn' s update fails", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some(anActivatedUserEycaCard))
+    );
+    updateMock.mockImplementationOnce(() =>
+      fromLeft(new Error("Cannot update User EYCA Card"))
+    );
+    const expireEycaActivityHandler = getExpireEycaActivityHandler(
+      userCgnModelMock as any
+    );
+    const response = await expireEycaActivityHandler(context, anActivityInput);
+    expect(response.kind).toBe("FAILURE");
+    if (response.kind === "FAILURE") {
+      expect(response.reason).toBe("Cannot update User EYCA Card");
+    }
+  });
+
+  it("should return success if userCgn' s update success", async () => {
+    findLastVersionByModelIdMock.mockImplementationOnce(() =>
+      taskEither.of(some(anActivatedUserEycaCard))
+    );
+    updateMock.mockImplementationOnce(() =>
+      taskEither.of({
+        ...anActivatedUserEycaCard,
+        card: { ...anActivatedEycaCard, status: ExpiredStatusEnum.EXPIRED }
+      })
+    );
+    const expireEycaActivityHandler = getExpireEycaActivityHandler(
+      userCgnModelMock as any
+    );
+    const response = await expireEycaActivityHandler(context, anActivityInput);
+    expect(response.kind).toBe("SUCCESS");
+  });
+});

--- a/ExpireEycaActivity/function.json
+++ b/ExpireEycaActivity/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/ExpireEycaActivity/index.js"
+}

--- a/ExpireEycaActivity/handler.ts
+++ b/ExpireEycaActivity/handler.ts
@@ -1,0 +1,69 @@
+import { Context } from "@azure/functions";
+import { fromOption, toError } from "fp-ts/lib/Either";
+import { identity } from "fp-ts/lib/function";
+import { fromEither } from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { StatusEnum as CardExpiredStatus } from "../generated/definitions/CardExpired";
+import { EycaCardActivated } from "../generated/definitions/EycaCardActivated";
+import { UserEycaCardModel } from "../models/user_eyca_card";
+import { ActivityResult, failure, success } from "../utils/activity";
+import { errorsToError } from "../utils/conversions";
+
+export const ActivityInput = t.interface({
+  fiscalCode: FiscalCode
+});
+
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+export const getExpireEycaActivityHandler = (
+  userEycaCardModel: UserEycaCardModel,
+  logPrefix: string = "ExpireEycaActivity"
+) => (context: Context, input: unknown): Promise<ActivityResult> => {
+  const fail = failure(context, logPrefix);
+  return fromEither(ActivityInput.decode(input))
+    .mapLeft(errs => fail(errorsToError(errs), "Cannot decode Activity Input"))
+    .chain(activityInput =>
+      userEycaCardModel
+        .findLastVersionByModelId([activityInput.fiscalCode])
+        .mapLeft(() =>
+          fail(
+            new Error(
+              "Cannot retrieve User EYCA Card for the provided fiscalCode"
+            )
+          )
+        )
+        .chain(maybeUserEycaCard =>
+          fromEither(
+            fromOption(
+              fail(
+                new Error("No User EYCA Card found for the provided fiscalCode")
+              )
+            )(maybeUserEycaCard)
+          )
+        )
+        .chain(userEycaCard =>
+          fromEither(EycaCardActivated.decode(userEycaCard.card)).bimap(
+            () =>
+              fail(
+                new Error("Cannot expire an EYCA Card that is not ACTIVATED")
+              ),
+            card => ({
+              ...userEycaCard,
+              card: {
+                ...card,
+                status: CardExpiredStatus.EXPIRED
+              }
+            })
+          )
+        )
+    )
+    .chain(_ =>
+      userEycaCardModel.update(_).bimap(
+        err => fail(toError(err), "Cannot update User EYCA Card"),
+        () => success()
+      )
+    )
+    .fold<ActivityResult>(identity, identity)
+    .run();
+};

--- a/ExpireEycaActivity/index.ts
+++ b/ExpireEycaActivity/index.ts
@@ -1,0 +1,21 @@
+﻿import {
+  USER_EYCA_CARD_COLLECTION_NAME,
+  UserEycaCardModel
+} from "../models/user_eyca_card";
+import { getConfigOrThrow } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+import { getExpireEycaActivityHandler } from "./handler";
+
+const config = getConfigOrThrow();
+
+const userEycaCardsContainer = cosmosdbClient
+  .database(config.COSMOSDB_CGN_DATABASE_NAME)
+  .container(USER_EYCA_CARD_COLLECTION_NAME);
+
+const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
+
+const expireEycaActivityHandler = getExpireEycaActivityHandler(
+  userEycaCardModel
+);
+
+export default expireEycaActivityHandler;

--- a/ExpireEycaOrchestrator/__tests__/index.test.ts
+++ b/ExpireEycaOrchestrator/__tests__/index.test.ts
@@ -1,0 +1,104 @@
+// tslint:disable: object-literal-sort-keys
+
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { handler } from "../index";
+
+const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
+
+const getInputMock = jest.fn().mockImplementation(() => ({
+  fiscalCode: aFiscalCode,
+  activationDate: new Date(),
+  expirationDate: new Date()
+}));
+
+const mockCallActivityWithRetry = jest.fn();
+
+const contextMockWithDf = {
+  ...contextMock,
+  df: {
+    callActivity: jest.fn(),
+    callActivityWithRetry: mockCallActivityWithRetry,
+    getInput: getInputMock,
+    setCustomStatus: jest.fn(),
+    createTimer: jest.fn().mockReturnValue("CreateTimer")
+  }
+};
+
+describe("ExpireEycaOrchestrator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should call the right activity to expire an EYCA card", async () => {
+    mockCallActivityWithRetry
+      // 1 SuccessEycaActivationActivity
+      .mockReturnValueOnce({ kind: "SUCCESS" })
+      .mockReturnValueOnce({ kind: "SUCCESS" });
+    // tslint:disable-next-line: no-any no-useless-cast
+    const orchestrator = handler(contextMockWithDf as any);
+
+    const res1 = orchestrator.next();
+    expect(res1.value.kind).toEqual("SUCCESS");
+
+    // Complete the orchestrator execution
+    const res2 = orchestrator.next(res1.value);
+    expect(res2.value.kind).toEqual("SUCCESS");
+
+    const res = orchestrator.next(res2.value);
+
+    orchestrator.next(res);
+
+    expect(contextMockWithDf.df.setCustomStatus).toHaveBeenNthCalledWith(
+      1,
+      "RUNNING"
+    );
+    expect(contextMockWithDf.df.setCustomStatus).toHaveBeenNthCalledWith(
+      2,
+      "UPDATED"
+    );
+    expect(contextMockWithDf.df.setCustomStatus).toHaveBeenNthCalledWith(
+      3,
+      "COMPLETED"
+    );
+    expect(res).toStrictEqual({ done: true, value: undefined });
+  });
+
+  it("should retry if it cannot decode expiration output", async () => {
+    mockCallActivityWithRetry
+      // 1 SuccessEycaActivationActivity
+      .mockReturnValueOnce({ kind: "WRONG" });
+    // tslint:disable-next-line: no-any no-useless-cast
+    const orchestrator = handler(contextMockWithDf as any);
+
+    // Complete the orchestrator execution
+    const res = orchestrator.next();
+    expect(res).toMatchObject({ value: { kind: "WRONG" } });
+
+    expect(contextMockWithDf.df.setCustomStatus).toHaveBeenNthCalledWith(
+      1,
+      "RUNNING"
+    );
+  });
+
+  it("should retry if EYCA expiration fails", async () => {
+    mockCallActivityWithRetry
+      // 1 SuccessEycaActivationActivity
+      .mockReturnValueOnce({ kind: "FAILURE" });
+    // tslint:disable-next-line: no-any no-useless-cast
+    const orchestrator = handler(contextMockWithDf as any);
+
+    const res1 = orchestrator.next();
+    expect(res1.value).toEqual({
+      kind: "FAILURE"
+    });
+
+    // Complete the orchestrator execution
+    const res = orchestrator.next(res1.value);
+    expect(res).toMatchObject({ value: false });
+
+    expect(contextMockWithDf.df.setCustomStatus).toHaveBeenNthCalledWith(
+      1,
+      "RUNNING"
+    );
+  });
+});

--- a/ExpireEycaOrchestrator/function.json
+++ b/ExpireEycaOrchestrator/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/StartEycaActivationOrchestrator/index.js"
+}

--- a/ExpireEycaOrchestrator/function.json
+++ b/ExpireEycaOrchestrator/function.json
@@ -6,5 +6,5 @@
       "direction": "in"
     }
   ],
-  "scriptFile": "../dist/StartEycaActivationOrchestrator/index.js"
+  "scriptFile": "../dist/ExpireEycaOrchestrator/index.js"
 }

--- a/ExpireEycaOrchestrator/index.ts
+++ b/ExpireEycaOrchestrator/index.ts
@@ -1,0 +1,100 @@
+﻿import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
+
+import * as df from "durable-functions";
+import * as t from "io-ts";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+
+import { ActivityInput as ExpireEycaActivityInput } from "../ExpireEycaActivity/handler";
+
+import { ActivityInput as SendMessageActivityInput } from "../SendMessageActivity/handler";
+import { ActivityResult } from "../utils/activity";
+import { getEycaExpirationMessage } from "../utils/messages";
+import {
+  getTrackExceptionAndThrowWithErrorStatus,
+  trackExceptionIfNotReplaying
+} from "../utils/orchestrators";
+import { internalRetryOptions } from "../utils/retry_policies";
+
+export const OrchestratorInput = t.interface({
+  fiscalCode: FiscalCode
+});
+export type OrchestratorInput = t.TypeOf<typeof OrchestratorInput>;
+
+export const handler = function*(
+  context: IOrchestrationFunctionContext,
+  logPrefix: string = "StartEycaActivationOrchestrator"
+): Generator {
+  const trackExAndThrowWithErrorStatus = getTrackExceptionAndThrowWithErrorStatus(
+    context,
+    logPrefix
+  );
+  const trackExIfNotReplaying = trackExceptionIfNotReplaying(context);
+
+  if (!context.df.isReplaying) {
+    context.df.setCustomStatus("RUNNING");
+  }
+
+  const input = context.df.getInput();
+
+  const { fiscalCode } = OrchestratorInput.decode(input).getOrElseL(e =>
+    trackExAndThrowWithErrorStatus(e, "eyca.expiration.exception.decode.input")
+  );
+  const tagOverrides = {
+    "ai.operation.id": fiscalCode,
+    "ai.operation.parentId": fiscalCode
+  };
+
+  try {
+    const eycaExpirationActivityInput = ExpireEycaActivityInput.encode({
+      fiscalCode
+    });
+
+    const eycaExpirationActivityResult = yield context.df.callActivityWithRetry(
+      "ExpireEycaActivity",
+      internalRetryOptions,
+      eycaExpirationActivityInput
+    );
+
+    const decodedEycaExpirationActivity = ActivityResult.decode(
+      eycaExpirationActivityResult
+    ).getOrElseL(_ =>
+      trackExAndThrowWithErrorStatus(
+        _,
+        "eyca.expiration.exception.decode.activityOutput"
+      )
+    );
+
+    if (decodedEycaExpirationActivity.kind !== "SUCCESS") {
+      trackExAndThrowWithErrorStatus(
+        new Error("Cannot expire EYCA Card"),
+        "eyca.expiration.exception.failure.activityOutput"
+      );
+    }
+    // keep tracking of UserEycaCard expiration successfully
+    context.df.setCustomStatus("UPDATED");
+
+    yield context.df.callActivityWithRetry(
+      "SendMessageActivity",
+      internalRetryOptions,
+      SendMessageActivityInput.encode({
+        checkProfile: false,
+        content: getEycaExpirationMessage(),
+        fiscalCode
+      })
+    );
+  } catch (err) {
+    context.log.error(`${logPrefix}|ERROR|${String(err)}`);
+    trackExIfNotReplaying({
+      exception: err,
+      properties: {
+        id: fiscalCode,
+        name: "eyca.expiration.error"
+      },
+      tagOverrides
+    });
+    return false;
+  }
+  context.df.setCustomStatus("COMPLETED");
+};
+
+export const index = df.orchestrator(handler);

--- a/UpdateExpiredCgn/handler.ts
+++ b/UpdateExpiredCgn/handler.ts
@@ -11,11 +11,11 @@ import { StatusEnum as CardExpiredStatusEnum } from "../generated/definitions/Ca
 import { StatusEnum as CardRevokedStatusEnum } from "../generated/definitions/CardRevoked";
 import { OrchestratorInput } from "../UpdateCgnOrchestrator/handler";
 import { initTelemetryClient, trackException } from "../utils/appinsights";
+import { getExpiredCardUsers } from "../utils/card_expiration";
 import {
   makeUpdateCgnOrchestratorId,
   terminateUpdateCgnOrchestratorTask
 } from "../utils/orchestrators";
-import { getExpiredCgnUsers } from "./table";
 
 const finish = () => Promise.resolve(void 0);
 
@@ -29,7 +29,7 @@ export const getUpdateExpiredCgnHandler = (
 ) => async (context: Context): Promise<unknown> => {
   const today = date_fns.format(Date.now(), "yyyy-MM-dd");
 
-  const errorOrExpiredCgnUsers = await getExpiredCgnUsers(
+  const errorOrExpiredCgnUsers = await getExpiredCardUsers(
     tableService,
     cgnExpirationTableName,
     today

--- a/UpdateExpiredCgn/handler.ts
+++ b/UpdateExpiredCgn/handler.ts
@@ -124,14 +124,14 @@ export const getUpdateExpiredCgnHandler = (
   );
 
   // tslint:disable-next-line: readonly-array
-  const taskArray = [];
+  const results = [];
   const tasksChunks = chunksOf(tasks, 100);
   for (const tasksChunk of tasksChunks) {
-    taskArray.push(
-      array
+    results.push(
+      await array
         .sequence(taskEither)(tasksChunk)
         .run()
     );
   }
-  return Promise.all([...taskArray]);
+  return results;
 };

--- a/UpdateExpiredEyca/function.json
+++ b/UpdateExpiredEyca/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+        "schedule": "0 0 0 * * *",
+        "name": "updateExpiredCgnTimer",
+        "type": "timerTrigger",
+        "direction": "in"
+    },
+    {
+      "name": "starter",
+      "type": "orchestrationClient",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/UpdateExpiredEyca/index.js"
+}

--- a/UpdateExpiredEyca/handler.ts
+++ b/UpdateExpiredEyca/handler.ts
@@ -1,0 +1,108 @@
+﻿import { Context } from "@azure/functions";
+import { TableService } from "azure-storage";
+import * as date_fns from "date-fns";
+import * as df from "durable-functions";
+import { array, chunksOf } from "fp-ts/lib/Array";
+import { isLeft, toError } from "fp-ts/lib/Either";
+import { taskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { OrchestratorInput } from "../ExpireEycaOrchestrator/index";
+import { StatusEnum as CardExpiredStatusEnum } from "../generated/definitions/CardExpired";
+import { StatusEnum } from "../generated/definitions/CardPending";
+import { initTelemetryClient, trackException } from "../utils/appinsights";
+import { getExpiredCardUsers } from "../utils/card_expiration";
+import {
+  makeEycaOrchestratorId,
+  terminateOrchestratorById
+} from "../utils/orchestrators";
+
+const finish = () => Promise.resolve(void 0);
+
+initTelemetryClient();
+const ORCHESTRATION_TERMINATION_REASON = "An highest priority EYCA expire orchestrator needs to start" as NonEmptyString;
+
+export const getUpdateExpiredEycaHandler = (
+  tableService: TableService,
+  eycaExpirationTableName: NonEmptyString,
+  logPrefix: string = "UpdateExpiredEycaHandler"
+) => async (context: Context): Promise<unknown> => {
+  const today = date_fns.format(Date.now(), "yyyy-MM-dd");
+
+  const errorOrExpiredEycaUsers = await getExpiredCardUsers(
+    tableService,
+    eycaExpirationTableName,
+    today
+  ).run();
+
+  if (isLeft(errorOrExpiredEycaUsers)) {
+    context.log.verbose(
+      `${logPrefix}|ERROR=${errorOrExpiredEycaUsers.value.message}`
+    );
+    return finish();
+  }
+
+  const expiredEycaUsers = errorOrExpiredEycaUsers.value;
+  context.log.info(
+    `${logPrefix}|Processing ${expiredEycaUsers.length} expired Eyca cards`
+  );
+
+  const client = df.getClient(context);
+  // trigger an update orchestrator for each user's CGN that expires
+
+  const tasks = expiredEycaUsers.map(({ fiscalCode }) =>
+    // first we terminate other possible Cgn update orchestrators
+    terminateOrchestratorById(
+      makeEycaOrchestratorId(fiscalCode, StatusEnum.PENDING),
+      client,
+      ORCHESTRATION_TERMINATION_REASON
+    )
+      .chain(() => {
+        context.log.info(
+          `${logPrefix}| Starting new EYCA expire orchestrator for fiscalCode=${fiscalCode.substr(
+            0,
+            6
+          )}`
+        );
+        // Now we try to start Expire operation
+        return tryCatch(
+          () =>
+            client.startNew(
+              "ExpireEycaOrchestrator",
+              makeEycaOrchestratorId(fiscalCode, CardExpiredStatusEnum.EXPIRED),
+              OrchestratorInput.encode({
+                fiscalCode
+              })
+            ),
+          toError
+        );
+      })
+      .mapLeft(err => {
+        context.log.error(
+          `${logPrefix}|Error while starting EYCA expiration for fiscalCode=${fiscalCode.substr(
+            0,
+            6
+          )}|ERROR=${err.message}`
+        );
+        trackException({
+          exception: err,
+          properties: {
+            id: fiscalCode,
+            name: "eyca.expire.error"
+          }
+        });
+        return err;
+      })
+  );
+
+  // tslint:disable-next-line: readonly-array
+  const taskArray = [];
+  const tasksChunks = chunksOf(tasks, 100);
+  for (const tasksChunk of tasksChunks) {
+    taskArray.push(
+      array
+        .sequence(taskEither)(tasksChunk)
+        .run()
+    );
+  }
+  return Promise.all([...taskArray]);
+};

--- a/UpdateExpiredEyca/index.ts
+++ b/UpdateExpiredEyca/index.ts
@@ -1,0 +1,14 @@
+﻿import { createTableService } from "azure-storage";
+import { getConfigOrThrow } from "../utils/config";
+import { getUpdateExpiredEycaHandler } from "./handler";
+
+const config = getConfigOrThrow();
+
+const tableService = createTableService(config.CGN_STORAGE_CONNECTION_STRING);
+
+const updateExpiredEycaHandler = getUpdateExpiredEycaHandler(
+  tableService,
+  config.EYCA_EXPIRATION_TABLE_NAME
+);
+
+export default updateExpiredEycaHandler;

--- a/utils/card_expiration.ts
+++ b/utils/card_expiration.ts
@@ -1,8 +1,8 @@
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { TableService } from "azure-storage";
 import { toError } from "fp-ts/lib/Either";
 import { taskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
-import { FiscalCode } from "italia-ts-commons/lib/strings";
 import { Timestamp } from "../generated/definitions/Timestamp";
 import {
   getPagedQuery,
@@ -12,18 +12,18 @@ import {
   TableEntry
 } from "../utils/table_storage";
 
-const ExpiredCgnRowKey = t.interface({
+const ExpiredCardRowKey = t.interface({
   activationDate: Timestamp,
   expirationDate: Timestamp,
   fiscalCode: FiscalCode
 });
 
-export type ExpiredCgnRowKey = t.TypeOf<typeof ExpiredCgnRowKey>;
+export type ExpiredCardRowKey = t.TypeOf<typeof ExpiredCardRowKey>;
 
 /**
  * Do something with the user hash extracted from the table entry
  */
-const withExpiredCgnRowFromEntry = (f: (s: ExpiredCgnRowKey) => void) => (
+const withExpiredCardRowFromEntry = (f: (s: ExpiredCardRowKey) => void) => (
   e: TableEntry
 ): void =>
   f({
@@ -37,24 +37,24 @@ const withExpiredCgnRowFromEntry = (f: (s: ExpiredCgnRowKey) => void) => (
  */
 export async function queryUsers(
   pagedQuery: PagedQuery
-): Promise<ReadonlySet<ExpiredCgnRowKey>> {
-  const entries = new Set<ExpiredCgnRowKey>();
-  const addToSet = withExpiredCgnRowFromEntry(s => entries.add(s));
+): Promise<ReadonlySet<ExpiredCardRowKey>> {
+  const entries = new Set<ExpiredCardRowKey>();
+  const addToSet = withExpiredCardRowFromEntry(s => entries.add(s));
   for await (const page of iterateOnPages(pagedQuery)) {
     page.forEach(addToSet);
   }
   return entries;
 }
 
-export const getExpiredCgnUsers = (
+export const getExpiredCardUsers = (
   tableService: TableService,
-  expiredCgnTableName: string,
+  expiredCardTableName: string,
   refDate: string
 ) =>
   // get a function that can query the expired cgns table
   taskEither
     .of<Error, ReturnType<typeof getPagedQuery>>(
-      getPagedQuery(tableService, expiredCgnTableName)
+      getPagedQuery(tableService, expiredCardTableName)
     )
     .map(pagedQuery => pagedQuery(queryFilterForKey(`${refDate}`)))
     .chain(cgnExpirationQuery =>

--- a/utils/messages.ts
+++ b/utils/messages.ts
@@ -57,6 +57,13 @@ export const getMessage = (card: Card): MessageContent => {
   return assertNever(card);
 };
 
+export const getEycaExpirationMessage = (): MessageContent =>
+  ({
+    subject: "La tua Carta EYCA è scaduta",
+    markdown: `Ti avvisiamo che da oggi non è più possibile utilizzare la tua Carta Giovani Nazionale per acquisti sul circuito EYCA.
+
+La Carta rimane valida per gli acquisti in Italia!`
+  } as MessageContent);
 export const getErrorMessage = (): MessageContent =>
   ({
     subject: "Abbiamo riscontrato dei problemi",

--- a/utils/orchestrators.ts
+++ b/utils/orchestrators.ts
@@ -146,13 +146,11 @@ export const checkUpdateCardIsRunning = (
     )
     .map(_ => false);
 
-export const terminateUpdateCgnOrchestratorTask = (
+export const terminateOrchestratorById = (
+  orchestratorId: string,
   client: DurableOrchestrationClient,
-  fiscalCode: FiscalCode,
-  status: string,
   reason: NonEmptyString
 ) => {
-  const orchestratorId = makeUpdateCgnOrchestratorId(fiscalCode, status);
   const voidTask = taskEither.of<Error, void>(void 0);
   return tryCatch(() => client.getStatus(orchestratorId), toError).chain(
     maybeStatus =>
@@ -176,6 +174,16 @@ export const terminateUpdateCgnOrchestratorTask = (
             )
         )
   );
+};
+
+export const terminateUpdateCgnOrchestratorTask = (
+  client: DurableOrchestrationClient,
+  fiscalCode: FiscalCode,
+  status: string,
+  reason: NonEmptyString
+) => {
+  const orchestratorId = makeUpdateCgnOrchestratorId(fiscalCode, status);
+  return terminateOrchestratorById(orchestratorId, client, reason);
 };
 
 export const trackExceptionAndThrow = (


### PR DESCRIPTION
#### List of Changes
- Add `UpdateExpiredEyca` trigger
- Add `ExpireEycaOrchestrator`
- Add `ExpireEycaActivity`
- Add tests and refactor some utility modules

#### Motivation and Context
n EYCA card must expires after a citizen has reached 31 years old, so it' necessary to schedule a trigger that could do this job, intended for:
- Read from a table which fiscalCodes reaches card expiration on the current day (It is filled during the EYCA's activation)
- Update EYCA card status to `EXPIRED`
- Send proper message to citizen with all the infos about EYCA expiration

Please refer to related [story](https://www.pivotaltracker.com/story/show/177116930) for further informations.

#### How Has This Been Tested?
It has been tested by performing unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.