### PR TITLE
[#IC-212] Activity retry refactoring

### DIFF
--- a/EnqueueEycaActivationActivity/__tests__/handler.test.ts
+++ b/EnqueueEycaActivationActivity/__tests__/handler.test.ts
@@ -7,8 +7,11 @@ import {
   ActivityInput,
   getEnqueueEycaActivationActivityHandler
 } from "../handler";
+import { pipe } from "fp-ts/lib/function";
+import { toError } from "fp-ts/lib/Either";
+import { testFail } from "../../__mocks__/mock";
 
-const enqueueEycaActivationMock = jest.fn().mockReturnValue(TE.of({}));
+const enqueueEycaActivationMock = jest.fn();
 
 const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
 const upsertMock = jest.fn().mockImplementation(() => TE.of({}));
@@ -25,22 +28,32 @@ describe("EnqueueEycaActivationActivity", () => {
     jest.clearAllMocks();
   });
 
-  it("should return failure if an error occurs during message enqueue", async () => {
+  it("should throw if an error occurs during message enqueue", async () => {
+    enqueueEycaActivationMock.mockImplementationOnce(() =>
+      TE.left(new Error("Error while enqueuing message"))
+    );
+
     const enqueueEycaActivationActivityHandler = getEnqueueEycaActivationActivityHandler(
       userCgnModelMock as any,
       enqueueEycaActivationMock as any
     );
 
-    enqueueEycaActivationMock.mockReturnValueOnce(
-      TE.left(new Error("Error while enqueuing message"))
-    );
-    const response = await enqueueEycaActivationActivityHandler(
-      context,
-      anActivityInput
-    );
-    expect(response.kind).toBe("FAILURE");
+    await pipe(
+      TE.tryCatch(
+        () => enqueueEycaActivationActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(e => {
+        expect(e).toEqual(
+          expect.objectContaining({
+            message:
+              "TRANSIENT FAILURE|ERROR=Cannot enqueue EYCA activation DETAIL=Error while enqueuing message"
+          })
+        );
+      }, testFail)
+    )();
   });
-  it("should return failure if an error occurs during Eyca card insert", async () => {
+  it("should throw if an error occurs during Eyca card insert", async () => {
     const enqueueEycaActivationActivityHandler = getEnqueueEycaActivationActivityHandler(
       userCgnModelMock as any,
       enqueueEycaActivationMock as any
@@ -49,14 +62,41 @@ describe("EnqueueEycaActivationActivity", () => {
     upsertMock.mockImplementationOnce(() =>
       TE.left(new Error("Error upserting"))
     );
-    const response = await enqueueEycaActivationActivityHandler(
-      context,
-      anActivityInput
+    await pipe(
+      TE.tryCatch(
+        () => enqueueEycaActivationActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(e => {
+        expect(e).toEqual(
+          expect.objectContaining({
+            message:
+              "TRANSIENT FAILURE|ERROR=Cannot insert EYCA Pending status DETAIL=Error upserting"
+          })
+        );
+      }, testFail)
+    )();
+  });
+
+  it("should return a permanent failure if activity input decode fails", async () => {
+    const enqueueEycaActivationActivityHandler = getEnqueueEycaActivationActivityHandler(
+      userCgnModelMock as any,
+      enqueueEycaActivationMock as any
     );
-    expect(response.kind).toBe("FAILURE");
+
+    await pipe(
+      TE.tryCatch(
+        () => enqueueEycaActivationActivityHandler(context, {}),
+        toError
+      ),
+      TE.bimap(testFail, response => {
+        expect(response.kind).toEqual("FAILURE");
+      })
+    )();
   });
 
   it("should return success if Eyca activation was enqueued successfully", async () => {
+    enqueueEycaActivationMock.mockImplementationOnce(() => TE.of({}));
     const enqueueEycaActivationActivityHandler = getEnqueueEycaActivationActivityHandler(
       userCgnModelMock as any,
       enqueueEycaActivationMock as any

--- a/ExpireEycaActivity/__tests__/handler.test.ts
+++ b/ExpireEycaActivity/__tests__/handler.test.ts
@@ -4,7 +4,7 @@ import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { none, some } from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { context } from "../../__mocks__/durable-functions";
-import { cgnActivatedDates } from "../../__mocks__/mock";
+import { cgnActivatedDates, testFail } from "../../__mocks__/mock";
 import { StatusEnum as ActivatedStatusEnum } from "../../generated/definitions/CardActivated";
 import {
   CardPending,
@@ -16,6 +16,8 @@ import { EycaCardActivated } from "../../generated/definitions/EycaCardActivated
 import { CcdbNumber } from "../../generated/eyca-api/CcdbNumber";
 import { UserEycaCard } from "../../models/user_eyca_card";
 import { ActivityInput, getExpireEycaActivityHandler } from "../handler";
+import { pipe } from "fp-ts/lib/function";
+import { toError } from "fp-ts/lib/Either";
 
 const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
 
@@ -50,53 +52,72 @@ describe("ExpireEycaActivity", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("should return failure if an error occurs during User Eyca Card retrieve", async () => {
+  it("should throw if an error occurs during User Eyca Card retrieve", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
       TE.left(toCosmosErrorResponse(new Error("query error")))
     );
     const expireEycaActivityHandler = getExpireEycaActivityHandler(
       userCgnModelMock as any
     );
-    const response = await expireEycaActivityHandler(context, anActivityInput);
-    expect(response.kind).toBe("FAILURE");
-    if (response.kind === "FAILURE") {
-      expect(response.reason).toBe(
-        "Cannot retrieve User EYCA Card for the provided fiscalCode"
-      );
-    }
+
+    await pipe(
+      TE.tryCatch(
+        () => expireEycaActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(e => {
+        expect(e).toBeDefined();
+        expect(e.message).toContain("TRANSIENT FAILURE");
+      }, testFail)
+    )();
   });
 
-  it("should return failure if no User Eyca Card was found", async () => {
+  it("should return permanent failure if no User Eyca Card was found", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() => TE.of(none));
     const expireEycaActivityHandler = getExpireEycaActivityHandler(
       userCgnModelMock as any
     );
-    const response = await expireEycaActivityHandler(context, anActivityInput);
-    expect(response.kind).toBe("FAILURE");
-    if (response.kind === "FAILURE") {
-      expect(response.reason).toBe(
-        "No User EYCA Card found for the provided fiscalCode"
-      );
-    }
+
+    await pipe(
+      TE.tryCatch(
+        () => expireEycaActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(testFail, response => {
+        expect(response.kind).toBe("FAILURE");
+        if (response.kind === "FAILURE") {
+          expect(response.reason).toBe(
+            "PERMANENT FAILURE|ERROR=No User EYCA Card found for the provided fiscalCode"
+          );
+        }
+      })
+    )();
   });
 
-  it("should return failure if User Eyca Card is not Active", async () => {
+  it("should return permanent failure if User Eyca Card is not Active", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
       TE.of(some(aUserCardPending))
     );
     const expireEycaActivityHandler = getExpireEycaActivityHandler(
       userCgnModelMock as any
     );
-    const response = await expireEycaActivityHandler(context, anActivityInput);
-    expect(response.kind).toBe("FAILURE");
-    if (response.kind === "FAILURE") {
-      expect(response.reason).toBe(
-        "Cannot expire an EYCA Card that is not ACTIVATED"
-      );
-    }
+    await pipe(
+      TE.tryCatch(
+        () => expireEycaActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(testFail, response => {
+        expect(response.kind).toBe("FAILURE");
+        if (response.kind === "FAILURE") {
+          expect(response.reason).toBe(
+            "PERMANENT FAILURE|ERROR=Cannot expire an EYCA Card that is not ACTIVATED"
+          );
+        }
+      })
+    )();
   });
 
-  it("should return failure if userCgn' s update fails", async () => {
+  it("should throw if userCgn' s update fails", async () => {
     findLastVersionByModelIdMock.mockImplementationOnce(() =>
       TE.of(some(anActivatedUserEycaCard))
     );
@@ -106,11 +127,16 @@ describe("ExpireEycaActivity", () => {
     const expireEycaActivityHandler = getExpireEycaActivityHandler(
       userCgnModelMock as any
     );
-    const response = await expireEycaActivityHandler(context, anActivityInput);
-    expect(response.kind).toBe("FAILURE");
-    if (response.kind === "FAILURE") {
-      expect(response.reason).toBe("Cannot update User EYCA Card");
-    }
+    await pipe(
+      TE.tryCatch(
+        () => expireEycaActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(e => {
+        expect(e).toBeDefined();
+        expect(e.message).toContain("TRANSIENT FAILURE");
+      }, testFail)
+    )();
   });
 
   it("should return success if userCgn' s update success", async () => {

--- a/ExpireEycaActivity/handler.ts
+++ b/ExpireEycaActivity/handler.ts
@@ -1,6 +1,6 @@
 import { Context } from "@azure/functions";
 import { toError } from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
@@ -8,8 +8,13 @@ import * as t from "io-ts";
 import { StatusEnum as CardExpiredStatus } from "../generated/definitions/CardExpired";
 import { EycaCardActivated } from "../generated/definitions/EycaCardActivated";
 import { UserEycaCardModel } from "../models/user_eyca_card";
-import { ActivityResult, failure, success } from "../utils/activity";
+import { ActivityResult, success } from "../utils/activity";
 import { errorsToError } from "../utils/conversions";
+import {
+  toPermanentFailure,
+  toTransientFailure,
+  trackFailure
+} from "../utils/errors";
 
 export const ActivityInput = t.interface({
   fiscalCode: FiscalCode
@@ -21,62 +26,67 @@ export const getExpireEycaActivityHandler = (
   userEycaCardModel: UserEycaCardModel,
   logPrefix: string = "ExpireEycaActivity"
 ) => (context: Context, input: unknown): Promise<ActivityResult> => {
-  const fail = failure(context, logPrefix);
+  const fail = trackFailure(context, logPrefix);
   return pipe(
     input,
     ActivityInput.decode,
     TE.fromEither,
-    TE.mapLeft(errs =>
-      fail(errorsToError(errs), "Cannot decode Activity Input")
+    TE.mapLeft(
+      flow(errorsToError, e =>
+        toPermanentFailure(e, "Cannot decode activity input")
+      )
     ),
     TE.chain(activityInput =>
       pipe(
         userEycaCardModel.findLastVersionByModelId([activityInput.fiscalCode]),
-        TE.mapLeft(() =>
-          fail(
-            new Error(
+        TE.mapLeft(
+          flow(toError, e =>
+            toTransientFailure(
+              e,
               "Cannot retrieve User EYCA Card for the provided fiscalCode"
-            )
-          )
-        ),
-        TE.chain(
-          TE.fromOption(() =>
-            fail(
-              new Error("No User EYCA Card found for the provided fiscalCode")
-            )
-          )
-        ),
-        TE.chain(userEycaCard =>
-          pipe(
-            userEycaCard.card,
-            EycaCardActivated.decode,
-            TE.fromEither,
-            TE.bimap(
-              () =>
-                fail(
-                  new Error("Cannot expire an EYCA Card that is not ACTIVATED")
-                ),
-              card => ({
-                ...userEycaCard,
-                card: {
-                  ...card,
-                  status: CardExpiredStatus.EXPIRED
-                }
-              })
-            )
-          )
-        ),
-        TE.chain(userEycaCard =>
-          pipe(
-            userEycaCardModel.update(userEycaCard),
-            TE.bimap(
-              err => fail(toError(err), "Cannot update User EYCA Card"),
-              () => success()
             )
           )
         )
       )
     ),
+    TE.chain(
+      TE.fromOption(() =>
+        toPermanentFailure(
+          new Error("No User EYCA Card found for the provided fiscalCode")
+        )
+      )
+    ),
+    TE.chain(userEycaCard =>
+      pipe(
+        userEycaCard.card,
+        EycaCardActivated.decode,
+        TE.fromEither,
+        TE.bimap(
+          () =>
+            toPermanentFailure(
+              new Error("Cannot expire an EYCA Card that is not ACTIVATED")
+            ),
+          card => ({
+            ...userEycaCard,
+            card: {
+              ...card,
+              status: CardExpiredStatus.EXPIRED
+            }
+          })
+        )
+      )
+    ),
+    TE.chain(userEycaCard =>
+      pipe(
+        userEycaCardModel.update(userEycaCard),
+        TE.bimap(
+          err =>
+            toTransientFailure(toError(err), "Cannot update User EYCA Card"),
+          success
+        )
+      )
+    ),
+    TE.mapLeft(fail),
     TE.toUnion
   )();
 };

--- a/ExpireEycaOrchestrator/index.ts
+++ b/ExpireEycaOrchestrator/index.ts
@@ -95,7 +95,7 @@ export const handler = function*(
   } catch (err) {
     context.log.error(`${logPrefix}|ERROR|${String(err)}`);
     trackExIfNotReplaying({
-      exception: err,
+      exception: E.toError(err),
       properties: {
         id: fiscalCode,
         name: "eyca.expiration.error"

--- a/StoreEycaExpirationActivity/__tests__/handler.test.ts
+++ b/StoreEycaExpirationActivity/__tests__/handler.test.ts
@@ -3,12 +3,14 @@ import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as date_fns from "date-fns";
 import * as TE from "fp-ts/lib/TaskEither";
 import { context } from "../../__mocks__/durable-functions";
-import { now } from "../../__mocks__/mock";
+import { now, testFail } from "../../__mocks__/mock";
 import * as tableUtils from "../../utils/table_storage";
 import {
   ActivityInput,
   getStoreEycaExpirationActivityHandler
 } from "../handler";
+import { pipe } from "fp-ts/lib/function";
+import { toError } from "fp-ts/lib/Either";
 
 const aFiscalCode = "RODFDS82S10H501T" as FiscalCode;
 const tableServiceMock = jest.fn();
@@ -29,7 +31,16 @@ describe("StoreCgnExpirationActivity", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("should return failure if an error occurs during EycaExpiration insert", async () => {
+
+  it("should return a permanent failure if any errors occurs on input decode", async () => {
+    const storeEycaExpirationActivityHandler = getStoreEycaExpirationActivityHandler(
+      tableServiceMock as any,
+      expiredEycaTableName
+    );
+    const response = await storeEycaExpirationActivityHandler(context, {});
+    expect(response.kind).toBe("FAILURE");
+  });
+  it("should throw if an error occurs during EycaExpiration insert", async () => {
     const storeEycaExpirationActivityHandler = getStoreEycaExpirationActivityHandler(
       tableServiceMock as any,
       expiredEycaTableName
@@ -38,11 +49,16 @@ describe("StoreCgnExpirationActivity", () => {
     insertEycaExpirationMock.mockImplementationOnce(_ =>
       jest.fn(() => TE.left(new Error("Entity Error")))
     );
-    const response = await storeEycaExpirationActivityHandler(
-      context,
-      anActivityInput
-    );
-    expect(response.kind).toBe("FAILURE");
+    await pipe(
+      TE.tryCatch(
+        () => storeEycaExpirationActivityHandler(context, anActivityInput),
+        toError
+      ),
+      TE.bimap(e => {
+        expect(e).toBeDefined();
+        expect(e.message).toContain("TRANSIENT FAILURE");
+      }, testFail)
+    )();
   });
 
   it("should return success if a EycaExpiration's insert succeded", async () => {

--- a/StoreEycaExpirationActivity/handler.ts
+++ b/StoreEycaExpirationActivity/handler.ts
@@ -1,12 +1,17 @@
 import { Context } from "@azure/functions";
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { TableService } from "azure-storage";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { Timestamp } from "../generated/definitions/Timestamp";
-import { ActivityResult, failure, success } from "../utils/activity";
+import { ActivityResult, success } from "../utils/activity";
 import { errorsToError } from "../utils/conversions";
+import {
+  toPermanentFailure,
+  toTransientFailure,
+  trackFailure
+} from "../utils/errors";
 import { insertCardExpiration } from "../utils/table_storage";
 
 export const ActivityInput = t.interface({
@@ -22,7 +27,7 @@ export const getStoreEycaExpirationActivityHandler = (
   eycaExpirationTableName: NonEmptyString,
   logPrefix: string = "StoreEycaExpirationActivity"
 ) => (context: Context, input: unknown): Promise<ActivityResult> => {
-  const fail = failure(context, logPrefix);
+  const fail = trackFailure(context, logPrefix);
   const insertEycaExpirationTask = insertCardExpiration(
     tableService,
     eycaExpirationTableName
@@ -31,8 +36,10 @@ export const getStoreEycaExpirationActivityHandler = (
     input,
     ActivityInput.decode,
     TE.fromEither,
-    TE.mapLeft(errs =>
-      fail(errorsToError(errs), "Cannot decode Activity Input")
+    TE.mapLeft(
+      flow(errorsToError, e =>
+        toPermanentFailure(e, "Cannot decode Activity Input")
+      )
     ),
     TE.chain(activityInput =>
       pipe(
@@ -42,11 +49,12 @@ export const getStoreEycaExpirationActivityHandler = (
           activityInput.expirationDate
         ),
         TE.bimap(
-          err => fail(err, "Cannot insert Eyca expiration tuple"),
+          err => toTransientFailure(err, "Cannot insert Eyca expiration tuple"),
           success
         )
       )
     ),
+    TE.mapLeft(fail),
     TE.toUnion
   )();
 };

--- a/SuccessEycaActivationActivity/handler.ts
+++ b/SuccessEycaActivationActivity/handler.ts
@@ -2,7 +2,7 @@
 import { Context } from "@azure/functions";
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { RedisClient } from "redis";
@@ -10,8 +10,13 @@ import { EycaAPIClient } from "../clients/eyca";
 import { StatusEnum } from "../generated/definitions/CardActivated";
 import { Timestamp } from "../generated/definitions/Timestamp";
 import { UserEycaCardModel } from "../models/user_eyca_card";
-import { ActivityResult, failure, success } from "../utils/activity";
+import { ActivityResult, success } from "../utils/activity";
 import { errorsToError } from "../utils/conversions";
+import {
+  toPermanentFailure,
+  toTransientFailure,
+  trackFailure
+} from "../utils/errors";
 import { preIssueCard, updateCard } from "./eyca";
 
 export const ActivityInput = t.interface({
@@ -30,19 +35,21 @@ export const getSuccessEycaActivationActivityHandler = (
   userEycaCardModel: UserEycaCardModel,
   logPrefix: string = "SuccessEycaActivationActivityHandler"
 ) => (context: Context, input: unknown): Promise<ActivityResult> => {
-  const fail = failure(context, logPrefix);
+  const fail = trackFailure(context, logPrefix);
   return pipe(
     input,
     ActivityInput.decode,
     TE.fromEither,
-    TE.mapLeft(errs =>
-      fail(errorsToError(errs), "Cannot decode Activity Input")
+    TE.mapLeft(
+      flow(errorsToError, e =>
+        toPermanentFailure(e, "Cannot decode Activity Input")
+      )
     ),
     TE.chain(({ fiscalCode, activationDate, expirationDate }) =>
       pipe(
         userEycaCardModel.findLastVersionByModelId([fiscalCode]),
         TE.mapLeft(() =>
-          fail(
+          toTransientFailure(
             new Error("Cannot retrieve EYCA card for the provided fiscalCode")
           )
         ),
@@ -50,7 +57,9 @@ export const getSuccessEycaActivationActivityHandler = (
           pipe(
             maybeEycaCard,
             TE.fromOption(() =>
-              fail(new Error("No EYCA card found for the provided fiscalCode"))
+              toPermanentFailure(
+                new Error("No EYCA card found for the provided fiscalCode")
+              )
             )
           )
         ),
@@ -70,8 +79,7 @@ export const getSuccessEycaActivationActivityHandler = (
                 expiration_date: expirationDate,
                 status: StatusEnum.ACTIVATED
               }
-            })),
-            TE.mapLeft(fail)
+            }))
           )
         )
       )
@@ -86,16 +94,19 @@ export const getSuccessEycaActivationActivityHandler = (
           _.card.card_number,
           _.card.expiration_date
         ),
-        TE.mapLeft(fail),
         TE.chain(() =>
           pipe(
             userEycaCardModel.update(_),
-            TE.mapLeft(err => fail(E.toError(err), "Cannot update EYCA card"))
+            TE.mapLeft(
+              flow(E.toError, e =>
+                toTransientFailure(e, "Cannot update EYCA card")
+              )
+            )
           )
         )
       )
     ),
-    TE.map(() => success()),
+    TE.bimap(fail, success),
     TE.toUnion
   )();
 };

--- a/UpdateCgnStatusActivity/handler.ts
+++ b/UpdateCgnStatusActivity/handler.ts
@@ -1,13 +1,18 @@
 import { Context } from "@azure/functions";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { Card } from "../generated/definitions/Card";
 import { UserCgnModel } from "../models/user_cgn";
-import { ActivityResult, failure, success } from "../utils/activity";
+import { ActivityResult, success } from "../utils/activity";
 import { errorsToError } from "../utils/conversions";
+import {
+  toPermanentFailure,
+  toTransientFailure,
+  trackFailure
+} from "../utils/errors";
 
 export const ActivityInput = t.interface({
   card: Card,
@@ -20,25 +25,31 @@ export const getUpdateCgnStatusActivityHandler = (
   userCgnModel: UserCgnModel,
   logPrefix: string = "UpdateCgnStatusActivity"
 ) => (context: Context, input: unknown): Promise<ActivityResult> => {
-  const fail = failure(context, logPrefix);
+  const fail = trackFailure(context, logPrefix);
   return pipe(
     input,
     ActivityInput.decode,
     TE.fromEither,
-    TE.mapLeft(errs =>
-      fail(errorsToError(errs), "Cannot decode Activity Input")
+    TE.mapLeft(
+      flow(errorsToError, e =>
+        toPermanentFailure(e, "Cannot decode Activity Input")
+      )
     ),
     TE.chain(activityInput =>
       pipe(
         userCgnModel.findLastVersionByModelId([activityInput.fiscalCode]),
         TE.mapLeft(() =>
-          fail(new Error("Cannot retrieve userCgn for the provided fiscalCode"))
+          toTransientFailure(
+            new Error("Cannot retrieve userCgn for the provided fiscalCode")
+          )
         ),
         TE.chain(maybeUserCgn =>
           pipe(
             maybeUserCgn,
             TE.fromOption(() =>
-              fail(new Error("No userCgn found for the provided fiscalCode"))
+              toPermanentFailure(
+                new Error("No userCgn found for the provided fiscalCode")
+              )
             )
           )
         ),
@@ -52,11 +63,12 @@ export const getUpdateCgnStatusActivityHandler = (
       pipe(
         userCgnModel.update(userCgn),
         TE.bimap(
-          err => fail(E.toError(err), "Cannot update userCgn"),
-          () => success()
+          flow(E.toError, e => toTransientFailure(e, "Cannot update userCgn")),
+          success
         )
       )
     ),
+    TE.mapLeft(fail),
     TE.toUnion
   )();
 };

--- a/__mocks__/mock.ts
+++ b/__mocks__/mock.ts
@@ -9,3 +9,5 @@ export const cgnActivatedDates = {
 };
 
 export const aFiscalCode = "DNLLSS99S20H501F" as FiscalCode;
+
+export const testFail = () => fail("Unexpected Value");

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,4 +1,9 @@
 import * as t from "io-ts";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { Context } from "@azure/functions";
+import { trackException } from "./appinsights";
+import { ActivityResultFailure } from "./activity";
 
 export const TransientFailure = t.interface({
   kind: t.literal("TRANSIENT"),
@@ -14,3 +19,60 @@ export type PermanentFailure = t.TypeOf<typeof PermanentFailure>;
 
 export const Failure = t.union([TransientFailure, PermanentFailure]);
 export type Failure = t.TypeOf<typeof Failure>;
+
+export const toTransientFailure = (
+  err: Error,
+  customReason?: string
+): Failure =>
+  pipe(
+    customReason,
+    O.fromNullable,
+    O.map(reason => `ERROR=${reason} DETAIL=${err.message}`),
+    O.getOrElse(() => `ERROR=${err.message}`),
+    errorMsg =>
+      Failure.encode({
+        kind: "TRANSIENT",
+        reason: `TRANSIENT FAILURE|${errorMsg}`
+      })
+  );
+
+export const toPermanentFailure = (
+  err: Error,
+  customReason?: string
+): Failure =>
+  pipe(
+    customReason,
+    O.fromNullable,
+    O.map(reason => `ERROR=${reason} DETAIL=${err.message}`),
+    O.getOrElse(() => `ERROR=${err.message}`),
+    errorMsg =>
+      Failure.encode({
+        kind: "PERMANENT",
+        reason: `PERMANENT FAILURE|${errorMsg}`
+      })
+  );
+
+export const trackFailure = (context: Context, logPrefix: string) => (
+  err: Failure
+): ActivityResultFailure => {
+  const error = TransientFailure.is(err)
+    ? `${logPrefix}|TRANSIENT_ERROR=${err.reason}`
+    : `${logPrefix}|FATAL|PERMANENT_ERROR=${err.reason}`;
+  trackException({
+    exception: new Error(error),
+    properties: {
+      detail: err.kind,
+      fatal: PermanentFailure.is(err).toString(),
+      isSuccess: false,
+      name: "cgn.exception.upsertSpecialService.failure"
+    }
+  });
+  context.log.error(error);
+  if (TransientFailure.is(err)) {
+    throw new Error(err.reason);
+  }
+  return {
+    kind: "FAILURE",
+    reason: err.reason
+  };
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR is needed in order to correctly manage activity retry in the whole CGN processes.
We have to separate activity failures into two different kind:
- Transient Failure that triggers a retry
- Permanent Failure that returns a common failure value to be logged
#### List of Changes
<!--- Describe your changes in detail -->
Intorduce Transient Failure and Permanent Failure in all activities uncovered by this logic
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required in order to ensure activity retrying if a transient failure occurs during execution
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.